### PR TITLE
feat: add responsive next admin dashboard components

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next";
+import {
+  BookOpen,
+  GraduationCap,
+  LayoutDashboard,
+  NotebookPen,
+  Settings,
+  Users,
+  LifeBuoy,
+  LogOut,
+  CalendarCheck,
+  ListChecks,
+} from "lucide-react";
+
+import { AddTutorForm } from "@/components/dashboard/add-tutor-form";
+import { DashboardActions } from "@/components/dashboard/dashboard-actions";
+import { DashboardStatsCards } from "@/components/dashboard/dashboard-stats-cards";
+import { RecentEnrollmentsTable } from "@/components/dashboard/recent-enrollments-table";
+import { SidebarNavigation } from "@/components/dashboard/sidebar-navigation";
+import { type ActionButtonConfig, type DashboardStat, type Enrollment, type NavItem, type OrganizationProfile } from "@/types/dashboard";
+
+export const metadata: Metadata = {
+  title: "Admin Dashboard • Infoverse",
+  description:
+    "Monitor courses, students, and tutor activity with a responsive Infoverse admin dashboard built for Next.js App Router.",
+};
+
+const brand: OrganizationProfile = {
+  name: "Infoverse",
+  initials: "IV",
+  tagline: "Learning Management",
+  href: "/admin",
+};
+
+const navigation: NavItem[] = [
+  {
+    id: "dashboard",
+    label: "Dashboard",
+    href: "/admin",
+    icon: LayoutDashboard,
+  },
+  {
+    id: "courses",
+    label: "Courses",
+    href: "/admin/courses",
+    icon: BookOpen,
+  },
+  {
+    id: "students",
+    label: "Students",
+    href: "/admin/students",
+    icon: GraduationCap,
+  },
+  {
+    id: "tutor",
+    label: "Tutor",
+    href: "/admin/tutors",
+    icon: Users,
+  },
+];
+
+const footerNavigation: NavItem[] = [
+  {
+    id: "settings",
+    label: "Settings",
+    href: "/admin/settings",
+    icon: Settings,
+  },
+  {
+    id: "help",
+    label: "Help",
+    href: "/admin/help",
+    icon: LifeBuoy,
+  },
+  {
+    id: "logout",
+    label: "Log out",
+    href: "/logout",
+    icon: LogOut,
+    ariaLabel: "Log out of the Infoverse admin dashboard",
+  },
+];
+
+const stats: DashboardStat[] = [
+  {
+    id: "total-courses",
+    label: "Total courses",
+    value: "5",
+    helperText: "Active courses published this term.",
+    icon: BookOpen,
+  },
+  {
+    id: "total-students",
+    label: "Total students enrolled",
+    value: "20",
+    helperText: "Learners actively progressing through content.",
+    icon: GraduationCap,
+  },
+  {
+    id: "recent-enrollments",
+    label: "Recent enrollments",
+    value: "8",
+    helperText: "New enrollments added in the last 7 days.",
+    icon: CalendarCheck,
+  },
+];
+
+const quickActions: ActionButtonConfig[] = [
+  {
+    id: "create-course",
+    label: "Create course",
+    href: "/admin/courses/new",
+    icon: NotebookPen,
+    description: "Build a new learning path",
+  },
+  {
+    id: "view-courses",
+    label: "View courses",
+    href: "/admin/courses",
+    icon: BookOpen,
+    description: "Browse all published classes",
+  },
+  {
+    id: "manage-enrollments",
+    label: "Manage enrollments",
+    href: "/admin/enrollments",
+    icon: ListChecks,
+    description: "Review learner progress",
+  },
+];
+
+const enrollments: Enrollment[] = [
+  {
+    id: "1",
+    learnerName: "Alex Rivera",
+    courseTitle: "Intro to Data Science",
+    enrolledOn: "2024-07-18",
+    status: "Active",
+    progress: 82,
+  },
+  {
+    id: "2",
+    learnerName: "Priya Desai",
+    courseTitle: "Creative Writing Fundamentals",
+    enrolledOn: "2024-07-20",
+    status: "Pending",
+    progress: 45,
+  },
+  {
+    id: "3",
+    learnerName: "Jordan Smith",
+    courseTitle: "Advanced UX Research",
+    enrolledOn: "2024-07-21",
+    status: "Completed",
+    progress: 100,
+  },
+];
+
+export default function AdminDashboardPage() {
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <div className="mx-auto flex max-w-[120rem] flex-col gap-8 pb-12 lg:flex-row">
+        <SidebarNavigation brand={brand} navItems={navigation} footerItems={footerNavigation} />
+        <main className="flex-1 space-y-10 px-4 pb-6 pt-8 sm:px-6 lg:px-10">
+          <header className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-sm font-medium uppercase tracking-wide text-slate-500">Admin</p>
+              <h1 className="text-3xl font-bold text-slate-900">Admin dashboard</h1>
+              <p className="text-sm text-slate-600">
+                Manage courses, monitor student engagement, and collaborate with tutors from one responsive workspace.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 self-start rounded-full bg-emerald-100 px-4 py-1 text-sm font-medium text-emerald-700 sm:self-auto">
+              System status: Operational
+            </div>
+          </header>
+
+          <DashboardStatsCards stats={stats} />
+
+          <DashboardActions buttons={quickActions} />
+
+          <RecentEnrollmentsTable enrollments={enrollments} />
+
+          <AddTutorForm />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/add-tutor-form.tsx
+++ b/components/dashboard/add-tutor-form.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface AddTutorFormProps {
+  onSubmit?: (email: string) => Promise<void> | void;
+}
+
+export function AddTutorForm({ onSubmit }: AddTutorFormProps) {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">("idle");
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("submitting");
+
+    try {
+      await onSubmit?.(email);
+      setStatus("success");
+      setEmail("");
+    } finally {
+      window.setTimeout(() => setStatus("idle"), 2000);
+    }
+  };
+
+  return (
+    <section aria-labelledby="add-tutor" className="space-y-4">
+      <div className="space-y-1">
+        <h2 id="add-tutor" className="text-xl font-semibold text-slate-900">
+          Add tutor
+        </h2>
+        <p className="text-sm text-slate-600">
+          Invite instructors to collaborate on new and existing courses.
+        </p>
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <label className="text-sm font-medium text-slate-700" htmlFor="tutor-email">
+          Tutor email
+        </label>
+        <input
+          id="tutor-email"
+          type="email"
+          name="tutor-email"
+          required
+          autoComplete="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="Enter tutor's email"
+          className="w-full rounded-lg border border-slate-300 px-4 py-2 text-base text-slate-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#33A1CD]"
+        />
+        <button
+          type="submit"
+          className={cn(
+            "inline-flex items-center justify-center gap-2 rounded-lg bg-[#DD7C5E] px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-[#c96d52] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#b95d42] disabled:cursor-not-allowed disabled:opacity-70",
+            status === "submitting" && "animate-pulse",
+          )}
+          disabled={status === "submitting"}
+        >
+          {status === "submitting" ? "Sending invite..." : "Send invite"}
+        </button>
+        <p aria-live="polite" className="text-sm text-emerald-600">
+          {status === "success" ? "Invitation sent successfully." : "\u00A0"}
+        </p>
+      </form>
+    </section>
+  );
+}

--- a/components/dashboard/dashboard-actions.tsx
+++ b/components/dashboard/dashboard-actions.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { type ActionButtonConfig } from "@/types/dashboard";
+
+export interface DashboardActionsProps {
+  buttons: ActionButtonConfig[];
+}
+
+export function DashboardActions({ buttons }: DashboardActionsProps) {
+  const [activeButton, setActiveButton] = useState<string | null>(null);
+
+  const handleInteraction = (button: ActionButtonConfig) => () => {
+    setActiveButton(button.id);
+    button.onClick?.();
+    window.setTimeout(() => setActiveButton(null), 240);
+  };
+
+  return (
+    <section aria-labelledby="dashboard-quick-actions" className="space-y-3">
+      <h2 id="dashboard-quick-actions" className="text-xl font-semibold text-slate-900">
+        Quick actions
+      </h2>
+      <div className="flex flex-wrap gap-3">
+        {buttons.map((button) => {
+          const Icon = button.icon;
+          const sharedClasses = cn(
+            "group inline-flex min-w-[12rem] flex-1 items-center justify-between gap-3 rounded-xl border border-transparent bg-[#DD7C5E] px-5 py-4 text-left text-white shadow-sm transition-all hover:-translate-y-0.5 hover:bg-[#c96d52] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#b95d42] focus-visible:ring-offset-slate-100 active:translate-y-0",
+            activeButton === button.id && "ring-2 ring-offset-2 ring-offset-slate-100 ring-[#b95d42]",
+          );
+
+          const content = (
+            <span className="flex w-full items-center justify-between gap-3">
+              <span className="flex flex-col">
+                <span className="text-base font-semibold">{button.label}</span>
+                {button.description ? (
+                  <span className="text-sm text-white/90">{button.description}</span>
+                ) : null}
+              </span>
+              <Icon aria-hidden="true" className="h-5 w-5 text-white/90 transition-transform group-hover:scale-110" />
+            </span>
+          );
+
+          if (button.href) {
+            return (
+              <Link
+                key={button.id}
+                href={button.href}
+                aria-label={button.ariaLabel ?? button.label}
+                className={sharedClasses}
+                onClick={handleInteraction(button)}
+              >
+                {content}
+              </Link>
+            );
+          }
+
+          return (
+            <button
+              key={button.id}
+              type="button"
+              aria-label={button.ariaLabel ?? button.label}
+              className={sharedClasses}
+              onClick={handleInteraction(button)}
+            >
+              {content}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/dashboard-stats-cards.tsx
+++ b/components/dashboard/dashboard-stats-cards.tsx
@@ -1,0 +1,40 @@
+import { type DashboardStat } from "@/types/dashboard";
+
+export interface DashboardStatsCardsProps {
+  stats: DashboardStat[];
+}
+
+export function DashboardStatsCards({ stats }: DashboardStatsCardsProps) {
+  return (
+    <section aria-labelledby="dashboard-statistics" className="space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <h2 id="dashboard-statistics" className="text-xl font-semibold text-slate-900">
+          Key metrics
+        </h2>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {stats.map((stat) => {
+          const Icon = stat.icon;
+          return (
+            <article
+              key={stat.id}
+              className="group rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 transition-shadow hover:shadow-md"
+              aria-label={`${stat.label} ${stat.value}`}
+            >
+              <div className="flex items-start gap-4">
+                <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#BDD0D2] text-[#1d5d75]">
+                  <Icon aria-hidden="true" className="h-6 w-6" />
+                </span>
+                <div>
+                  <p className="text-sm font-medium text-slate-500">{stat.label}</p>
+                  <p className="mt-2 text-3xl font-semibold text-slate-900">{stat.value}</p>
+                  <p className="mt-3 text-sm text-slate-600">{stat.helperText}</p>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/recent-enrollments-table.tsx
+++ b/components/dashboard/recent-enrollments-table.tsx
@@ -1,0 +1,107 @@
+import { formatEnrollmentDate, getInitials } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+import { type Enrollment } from "@/types/dashboard";
+
+export interface RecentEnrollmentsTableProps {
+  enrollments: Enrollment[];
+}
+
+export function RecentEnrollmentsTable({
+  enrollments,
+}: RecentEnrollmentsTableProps) {
+  return (
+    <section aria-labelledby="recent-enrollments" className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h2 id="recent-enrollments" className="text-xl font-semibold text-slate-900">
+          Recent enrollments
+        </h2>
+        <p className="text-sm text-slate-600">
+          Latest activity from the past two weeks.
+        </p>
+      </div>
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200" role="grid">
+            <thead className="bg-slate-50">
+              <tr>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600"
+                >
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600"
+                >
+                  Course
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600"
+                >
+                  Enrolled on
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600"
+                >
+                  Progress
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {enrollments.map((enrollment) => (
+                <tr
+                  key={enrollment.id}
+                  className="transition-colors hover:bg-slate-50 focus-within:bg-slate-50"
+                >
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <div className="flex items-center gap-3">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[#BDD0D2] text-sm font-semibold text-[#1d5d75]">
+                        {getInitials(enrollment.learnerName)}
+                      </span>
+                      <div>
+                        <p className="text-sm font-semibold text-slate-900">
+                          {enrollment.learnerName}
+                        </p>
+                        <p className="text-sm text-slate-600">{enrollment.status}</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-slate-700">
+                    {enrollment.courseTitle}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-slate-700">
+                    {formatEnrollmentDate(enrollment.enrolledOn)}
+                  </td>
+                  <td className="px-6 py-4">
+                    <div className="flex flex-col gap-1">
+                      <span className="text-sm font-medium text-slate-800">
+                        {enrollment.progress}% complete
+                      </span>
+                      <span className="h-2 w-full rounded-full bg-slate-200">
+                        <span
+                          style={{ width: `${Math.min(enrollment.progress, 100)}%` }}
+                          className={cn(
+                            "block h-full rounded-full bg-[#33A1CD] transition-all",
+                            enrollment.progress >= 100 && "bg-emerald-500",
+                          )}
+                        />
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {enrollments.length === 0 ? (
+          <div className="px-6 py-10 text-center text-sm text-slate-600">
+            No enrollments recorded this week.
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/sidebar-navigation.tsx
+++ b/components/dashboard/sidebar-navigation.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  LogOut,
+  Settings,
+  LifeBuoy,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { type NavItem, type OrganizationProfile } from "@/types/dashboard";
+
+export interface SidebarNavigationProps {
+  brand: OrganizationProfile;
+  navItems: NavItem[];
+  footerItems?: NavItem[];
+}
+
+export function SidebarNavigation({
+  brand,
+  navItems,
+  footerItems = [
+    {
+      id: "settings",
+      label: "Settings",
+      href: "#settings",
+      icon: Settings,
+    },
+    {
+      id: "logout",
+      label: "Log out",
+      href: "#logout",
+      icon: LogOut,
+    },
+    {
+      id: "help",
+      label: "Help",
+      href: "#help",
+      icon: LifeBuoy,
+    },
+  ],
+}: SidebarNavigationProps) {
+  const pathname = usePathname();
+
+  return (
+    <aside
+      aria-label="Admin navigation"
+      className="w-full bg-[#33A1CD] text-white shadow-lg lg:w-72 lg:min-h-screen"
+    >
+      <div className="flex h-full flex-col justify-between gap-6 p-6">
+        <div className="space-y-8">
+          <div className="flex items-center gap-3 rounded-xl bg-white/10 p-4">
+            <span
+              aria-hidden="true"
+              className="flex h-12 w-12 items-center justify-center rounded-lg bg-white text-lg font-semibold text-[#33A1CD]"
+            >
+              {brand.initials}
+            </span>
+            <div>
+              <Link
+                href={brand.href ?? "#"}
+                className="text-lg font-semibold text-white transition-colors hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+              >
+                {brand.name}
+              </Link>
+              {brand.tagline ? (
+                <p className="text-sm text-white/80">{brand.tagline}</p>
+              ) : null}
+            </div>
+          </div>
+
+          <nav aria-label="Primary">
+            <ul className="space-y-1">
+              {navItems.map((item) => {
+                const isActive = pathname === item.href || pathname === item.href.replace(/\/#.*/, "");
+                const Icon = item.icon ?? LayoutDashboard;
+
+                return (
+                  <li key={item.id}>
+                    <Link
+                      href={item.href}
+                      aria-label={item.ariaLabel ?? item.label}
+                      className={cn(
+                        "group flex items-center gap-3 rounded-lg px-4 py-3 text-base font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white/70 focus-visible:ring-offset-[#33A1CD]",
+                        isActive
+                          ? "bg-white text-[#1d5d75] shadow"
+                          : "hover:bg-white/10 hover:text-white",
+                      )}
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        className={cn(
+                          "h-5 w-5",
+                          isActive ? "text-[#33A1CD]" : "text-white/90 group-hover:text-white",
+                        )}
+                      />
+                      <span>{item.label}</span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+        </div>
+
+        {footerItems.length ? (
+          <div>
+            <div className="hidden h-px bg-white/20 lg:block" />
+            <ul className="mt-4 space-y-1" aria-label="Secondary">
+              {footerItems.map((item) => {
+                const Icon = item.icon ?? LayoutDashboard;
+                return (
+                  <li key={item.id}>
+                    <Link
+                      href={item.href}
+                      aria-label={item.ariaLabel ?? item.label}
+                      className="flex items-center gap-3 rounded-lg px-4 py-3 text-base transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white/70 focus-visible:ring-offset-[#33A1CD]"
+                    >
+                      <Icon aria-hidden="true" className="h-5 w-5 text-white/90" />
+                      <span>{item.label}</span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -1,0 +1,21 @@
+export const formatEnrollmentDate = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+};
+
+export const getInitials = (name: string): string => {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "2.1.1",
         "lucide-react": "^0.453.0",
+        "next": "^14.2.15",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.1",
@@ -1300,6 +1301,156 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@next/env": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.32.tgz",
+      "integrity": "sha512-n9mQdigI6iZ/DF6pCTwMKeWgF2e8lg7qgt5M7HXMLtyhZYMnf/u905M18sSpPmHL9MKp9JHo56C6jrD2EvWxng==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.32.tgz",
+      "integrity": "sha512-osHXveM70zC+ilfuFa/2W6a1XQxJTvEhzEycnjUaVE8kpUS09lDpiDDX2YLdyFCzoUbvbo5r0X1Kp4MllIOShw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.32.tgz",
+      "integrity": "sha512-P9NpCAJuOiaHHpqtrCNncjqtSBi1f6QUdHK/+dNabBIXB2RUFWL19TY1Hkhu74OvyNQEYEzzMJCMQk5agjw1Qg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.32.tgz",
+      "integrity": "sha512-v7JaO0oXXt6d+cFjrrKqYnR2ubrD+JYP7nQVRZgeo5uNE5hkCpWnHmXm9vy3g6foMO8SPwL0P3MPw1c+BjbAzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.32.tgz",
+      "integrity": "sha512-tA6sIKShXtSJBTH88i0DRd6I9n3ZTirmwpwAqH5zdJoQF7/wlJXR8DkPmKwYl5mFWhEKr5IIa3LfpMW9RRwKmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.32.tgz",
+      "integrity": "sha512-7S1GY4TdnlGVIdeXXKQdDkfDysoIVFMD0lJuVVMeb3eoVjrknQ0JNN7wFlhCvea0hEk0Sd4D1hedVChDKfV2jw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.32.tgz",
+      "integrity": "sha512-OHHC81P4tirVa6Awk6eCQ6RBfWl8HpFsZtfEkMpJ5GjPsJ3nhPe6wKAJUZ/piC8sszUkAgv3fLflgzPStIwfWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.32.tgz",
+      "integrity": "sha512-rORQjXsAFeX6TLYJrCG5yoIDj+NKq31Rqwn8Wpn/bkPNy5rTHvOXkW8mLFonItS7QC6M+1JIIcLe+vOCTOYpvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.32.tgz",
+      "integrity": "sha512-jHUeDPVHrgFltqoAqDB6g6OStNnFxnc7Aks3p0KE0FbwAvRg6qWKYF5mSTdCTxA3axoSAUwxYdILzXJfUwlHhA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.32.tgz",
+      "integrity": "sha512-2N0lSoU4GjfLSO50wvKpMQgKd4HdI2UHEhQPPPnlgfBJlOgJxkjpkYBqzk08f1gItBB6xF/n+ykso2hgxuydsA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1936,6 +2087,22 @@
         "win32"
       ]
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2165,6 +2332,17 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2178,7 +2356,6 @@
       "version": "1.0.30001741",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
       "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2230,6 +2407,12 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2547,6 +2730,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2816,6 +3005,84 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.32.tgz",
+      "integrity": "sha512-fg5g0GZ7/nFc09X8wLe6pNSU8cLWbLRG3TZzPJ1BJvi2s9m7eF991se67wliM9kR5yLHRkyGKU49MMx58s3LJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.32",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.32",
+        "@next/swc-darwin-x64": "14.2.32",
+        "@next/swc-linux-arm64-gnu": "14.2.32",
+        "@next/swc-linux-arm64-musl": "14.2.32",
+        "@next/swc-linux-x64-gnu": "14.2.32",
+        "@next/swc-linux-x64-musl": "14.2.32",
+        "@next/swc-win32-arm64-msvc": "14.2.32",
+        "@next/swc-win32-ia32-msvc": "14.2.32",
+        "@next/swc-win32-x64-msvc": "14.2.32"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-releases": {
@@ -3337,6 +3604,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -3431,6 +3706,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/sucrase": {
@@ -3573,6 +3871,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "clsx": "2.1.1",
     "lucide-react": "^0.453.0",
+    "next": "^14.2.15",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,9 +20,17 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
-    "src"
+    "src",
+    "app",
+    "components",
+    "lib",
+    "types"
   ]
 }

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -1,0 +1,43 @@
+import { type LucideIcon } from "lucide-react";
+
+export interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  ariaLabel?: string;
+}
+
+export interface DashboardStat {
+  id: string;
+  label: string;
+  value: string;
+  helperText: string;
+  icon: LucideIcon;
+}
+
+export interface ActionButtonConfig {
+  id: string;
+  label: string;
+  href?: string;
+  icon: LucideIcon;
+  ariaLabel?: string;
+  description?: string;
+  onClick?: () => void;
+}
+
+export interface Enrollment {
+  id: string;
+  learnerName: string;
+  courseTitle: string;
+  enrolledOn: string;
+  status: "Active" | "Pending" | "Completed";
+  progress: number;
+}
+
+export interface OrganizationProfile {
+  name: string;
+  initials: string;
+  tagline?: string;
+  href?: string;
+}


### PR DESCRIPTION
## Summary
- add a Next.js App Router admin dashboard page with responsive layout and sample data
- create reusable sidebar, stats cards, quick actions, enrollments table, and add tutor components styled with Tailwind
- configure shared TypeScript types, utilities, and path aliases for the new Next.js structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02d9a6ed8832ab65cdc4890ecdcb2