### PR TITLE
Create course management page components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.1",
         "tailwind-merge": "2.5.4",
-        "tailwindcss-animate": "1.0.7"
+        "tailwindcss-animate": "1.0.7",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@animaapp/vite-plugin-screen-graph": "^0.1.5",
@@ -3806,6 +3807,15 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.1",
+    "class-variance-authority": "^0.7.0",
     "clsx": "2.1.1",
     "lucide-react": "^0.453.0",
     "react": "^18.2.0",
@@ -16,9 +19,7 @@
     "react-router-dom": "^6.8.1",
     "tailwind-merge": "2.5.4",
     "tailwindcss-animate": "1.0.7",
-    "@radix-ui/react-tabs": "^1.1.1",
-    "@radix-ui/react-slot": "^1.1.0",
-    "class-variance-authority": "^0.7.0"
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@animaapp/vite-plugin-screen-graph": "^0.1.5",

--- a/src/app/(admin)/components/sidebar.tsx
+++ b/src/app/(admin)/components/sidebar.tsx
@@ -1,0 +1,84 @@
+import type { ComponentType } from "react";
+import {
+  BookOpen,
+  HelpCircle,
+  LayoutDashboard,
+  LogOut,
+  Settings,
+  UserRound,
+  Users,
+} from "lucide-react";
+import { cn } from "../../../../lib/utils";
+
+interface SidebarNavItem {
+  label: string;
+  href: string;
+  icon: ComponentType<{ className?: string }>;
+}
+
+interface SidebarProps {
+  activePath?: string;
+}
+
+const primaryItems: SidebarNavItem[] = [
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Courses", href: "/courses", icon: BookOpen },
+  { label: "Students", href: "/students", icon: Users },
+  { label: "Tutor", href: "/tutor", icon: UserRound },
+];
+
+const secondaryItems: SidebarNavItem[] = [
+  { label: "Settings", href: "/settings", icon: Settings },
+  { label: "Log out", href: "/logout", icon: LogOut },
+  { label: "Help", href: "/help", icon: HelpCircle },
+];
+
+const ItemLink = ({
+  item,
+  isActive,
+}: {
+  item: SidebarNavItem;
+  isActive: boolean;
+}) => {
+  const Icon = item.icon;
+  return (
+    <a
+      href={item.href}
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-4 py-3 text-base font-medium text-black transition-colors hover:bg-white/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#33a1cd]",
+        isActive && "bg-[#bdd0d2]",
+      )}
+      aria-current={isActive ? "page" : undefined}
+    >
+      <Icon className="h-5 w-5" aria-hidden="true" />
+      <span>{item.label}</span>
+    </a>
+  );
+};
+
+export const Sidebar = ({ activePath = "/dashboard" }: SidebarProps): JSX.Element => {
+  return (
+    <aside className="flex h-full w-full max-w-[220px] flex-col justify-between rounded-2xl bg-[#33a1cd]/10 p-6 backdrop-blur">
+      <div>
+        <div className="mb-10 flex items-center gap-3 rounded-xl bg-[#f3f3f3] px-4 py-3 text-black shadow-sm">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white text-sm font-semibold text-black">
+            IV
+          </div>
+          <div className="text-lg font-medium">Infoverse</div>
+        </div>
+
+        <nav aria-label="Main navigation" className="space-y-2">
+          {primaryItems.map((item) => (
+            <ItemLink key={item.label} item={item} isActive={activePath === item.href} />
+          ))}
+        </nav>
+      </div>
+
+      <nav aria-label="Secondary navigation" className="space-y-2">
+        {secondaryItems.map((item) => (
+          <ItemLink key={item.label} item={item} isActive={false} />
+        ))}
+      </nav>
+    </aside>
+  );
+};

--- a/src/app/(admin)/courses/[courseId]/page.tsx
+++ b/src/app/(admin)/courses/[courseId]/page.tsx
@@ -1,0 +1,43 @@
+import type { PropsWithChildren } from "react";
+import { Sidebar } from "../../components/sidebar";
+import { CourseForm } from "../_components/course-form";
+import { fetchCourseById } from "../_lib/course-actions";
+
+interface CoursePageProps {
+  params: {
+    courseId: string;
+  };
+}
+
+const PageWrapper = ({ children }: PropsWithChildren): JSX.Element => (
+  <div className="min-h-screen bg-white px-4 py-6 sm:px-6 lg:px-10">
+    <div className="mx-auto max-w-[1440px]">
+      <div className="flex flex-col gap-6 rounded-3xl bg-[#33a1cd] p-4 sm:p-6 lg:flex-row lg:p-8">
+        {children}
+      </div>
+    </div>
+  </div>
+);
+
+export default async function CourseDetailsPage({ params }: CoursePageProps): Promise<JSX.Element> {
+  const isCreateMode = params.courseId === "new";
+  const course = isCreateMode ? null : await fetchCourseById(params.courseId);
+  const resolvedMode: "create" | "edit" = !course || isCreateMode ? "create" : "edit";
+  const courseNotFound = !isCreateMode && !course;
+
+  return (
+    <PageWrapper>
+      <div className="lg:w-64">
+        <Sidebar activePath="/courses" />
+      </div>
+      <main className="flex-1 rounded-2xl bg-[#f3f3f3] p-6 shadow-sm sm:p-10">
+        {courseNotFound && (
+          <div className="mb-6 rounded-xl border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">
+            We couldn&apos;t find the course you were looking for. You can create a new course below.
+          </div>
+        )}
+        <CourseForm course={course ?? undefined} mode={resolvedMode} />
+      </main>
+    </PageWrapper>
+  );
+}

--- a/src/app/(admin)/courses/_components/course-form.tsx
+++ b/src/app/(admin)/courses/_components/course-form.tsx
@@ -1,0 +1,568 @@
+"use client";
+
+import type { ChangeEvent, FocusEvent, FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ActionButton } from "../../../../components/form/action-button";
+import { Input } from "../../../../components/form/input";
+import { Textarea } from "../../../../components/form/textarea";
+import {
+  buildCoursePayload,
+  Course,
+  CourseFormState,
+  courseFormSchema,
+  emptyCourseForm,
+  formStateFromCourse,
+} from "../_types/course";
+import { persistCourse, removeCourse } from "../_lib/course-actions";
+
+interface CourseFormProps {
+  course?: Course;
+  mode: "create" | "edit";
+}
+
+type Feedback = {
+  type: "success" | "error" | "info";
+  message: string;
+};
+
+type FieldName = keyof CourseFormState;
+
+const fieldOrder: FieldName[] = [
+  "title",
+  "instructor",
+  "price",
+  "category",
+  "description",
+  "syllabus",
+];
+
+const feedbackStyles: Record<Feedback["type"], string> = {
+  success: "border border-green-200 bg-green-50 text-green-800",
+  error: "border border-red-200 bg-red-50 text-red-800",
+  info: "border border-blue-200 bg-blue-50 text-blue-800",
+};
+
+export const CourseForm = ({ course, mode }: CourseFormProps): JSX.Element => {
+  const [formValues, setFormValues] = useState<CourseFormState>(
+    course ? formStateFromCourse(course) : emptyCourseForm,
+  );
+  const [persistedCourse, setPersistedCourse] = useState<Course | undefined>(course);
+  const [errors, setErrors] = useState<Partial<Record<FieldName, string>>>({});
+  const [touched, setTouched] = useState<Partial<Record<FieldName, boolean>>>({});
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [formSubmitted, setFormSubmitted] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isAutoSaving, setIsAutoSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(course?.updatedAt ?? null);
+
+  const autoSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const feedbackRef = useRef<HTMLDivElement>(null);
+  const cancelDeleteRef = useRef<HTMLButtonElement>(null);
+  const isFirstRender = useRef(true);
+
+  const titleRef = useRef<HTMLInputElement>(null);
+  const instructorRef = useRef<HTMLInputElement>(null);
+  const priceRef = useRef<HTMLInputElement>(null);
+  const categoryRef = useRef<HTMLInputElement>(null);
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
+  const syllabusRef = useRef<HTMLTextAreaElement>(null);
+
+  const fieldRefs = useMemo(
+    () => ({
+      title: titleRef,
+      instructor: instructorRef,
+      price: priceRef,
+      category: categoryRef,
+      description: descriptionRef,
+      syllabus: syllabusRef,
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    setFormValues(course ? formStateFromCourse(course) : emptyCourseForm);
+    setPersistedCourse(course);
+    setErrors({});
+    setTouched({});
+    setFeedback(null);
+    setFormSubmitted(false);
+    setIsDirty(false);
+    setLastSavedAt(course?.updatedAt ?? null);
+  }, [course]);
+
+  useEffect(() => {
+    if (feedback) {
+      feedbackRef.current?.focus();
+    }
+  }, [feedback]);
+
+  useEffect(() => {
+    if (showDeleteModal) {
+      cancelDeleteRef.current?.focus();
+    }
+  }, [showDeleteModal]);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    if (!isDirty || isSaving || isDeleting || showDeleteModal) {
+      return;
+    }
+
+    const validation = courseFormSchema.safeParse(formValues);
+    if (!validation.success) {
+      return;
+    }
+
+    if (autoSaveTimeoutRef.current) {
+      clearTimeout(autoSaveTimeoutRef.current);
+    }
+
+    autoSaveTimeoutRef.current = setTimeout(async () => {
+      setIsAutoSaving(true);
+      try {
+        const payload = buildCoursePayload(formValues, persistedCourse);
+        const savedCourse = await persistCourse(payload, { autoSave: true });
+        setPersistedCourse(savedCourse);
+        setFormValues(formStateFromCourse(savedCourse));
+        setLastSavedAt(savedCourse.updatedAt);
+        setIsDirty(false);
+        setFeedback((current) =>
+          current?.type === "success"
+            ? current
+            : {
+                type: "info",
+                message: "Draft saved automatically.",
+              },
+        );
+      } catch (error) {
+        setFeedback({
+          type: "error",
+          message:
+            error instanceof Error ? error.message : "We couldn't auto-save your changes. Please try again.",
+        });
+      } finally {
+        setIsAutoSaving(false);
+      }
+    }, 2000);
+
+    return () => {
+      if (autoSaveTimeoutRef.current) {
+        clearTimeout(autoSaveTimeoutRef.current);
+      }
+    };
+  }, [formValues, isDirty, isSaving, isDeleting, showDeleteModal, persistedCourse]);
+
+  const heading = "Course Details";
+  const subheading = useMemo(() => {
+    if (mode === "create" && !persistedCourse) {
+      return "Create a new course by filling in the details below.";
+    }
+
+    if (!persistedCourse) {
+      return "Update the course information.";
+    }
+
+    return `Editing ${persistedCourse.title}`;
+  }, [mode, persistedCourse]);
+
+  const helperText = useMemo(() => {
+    if (isAutoSaving) {
+      return "Saving draft...";
+    }
+
+    if (lastSavedAt) {
+      const savedTime = new Date(lastSavedAt).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      return `Last saved at ${savedTime}`;
+    }
+
+    return "All fields are required.";
+  }, [isAutoSaving, lastSavedAt]);
+
+  const handleFieldValidation = useCallback(
+    (field: FieldName, value: string) => {
+      const result = courseFormSchema.safeParse({
+        ...formValues,
+        [field]: value,
+      });
+
+      if (result.success) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }));
+        return true;
+      }
+
+      const fieldError = result.error.flatten().fieldErrors[field]?.[0];
+      setErrors((prev) => ({ ...prev, [field]: fieldError }));
+      return false;
+    },
+    [formValues],
+  );
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { name, value } = event.target;
+      const field = name as FieldName;
+      const sanitizedValue = field === "price" ? value.replace(/[^0-9.]/g, "") : value;
+
+      setFormValues((prev) => ({
+        ...prev,
+        [field]: sanitizedValue,
+      }));
+      setIsDirty(true);
+
+      if (touched[field]) {
+        handleFieldValidation(field, sanitizedValue);
+      }
+    },
+    [handleFieldValidation, touched],
+  );
+
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { name, value } = event.target;
+      const field = name as FieldName;
+
+      setTouched((prev) => ({ ...prev, [field]: true }));
+      handleFieldValidation(field, value);
+    },
+    [handleFieldValidation],
+  );
+
+  const validateForm = useCallback(() => {
+    const validation = courseFormSchema.safeParse(formValues);
+    if (validation.success) {
+      setErrors({});
+      return true;
+    }
+
+    const fieldErrors = validation.error.flatten().fieldErrors;
+    const nextErrors: Partial<Record<FieldName, string>> = {};
+    fieldOrder.forEach((field) => {
+      const message = fieldErrors[field]?.[0];
+      if (message) {
+        nextErrors[field] = message;
+      }
+    });
+    setErrors(nextErrors);
+    return false;
+  }, [formValues]);
+
+  const focusFirstError = useCallback(() => {
+    for (const field of fieldOrder) {
+      if (errors[field]) {
+        fieldRefs[field]?.current?.focus();
+        break;
+      }
+    }
+  }, [errors, fieldRefs]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setFormSubmitted(true);
+      setFeedback(null);
+
+      const isValid = validateForm();
+      if (!isValid) {
+        setFeedback({ type: "error", message: "Please fix the errors highlighted below." });
+        setTimeout(focusFirstError, 0);
+        return;
+      }
+
+      setIsSaving(true);
+
+      try {
+        const payload = buildCoursePayload(formValues, persistedCourse);
+        const savedCourse = await persistCourse(payload);
+        setPersistedCourse(savedCourse);
+        setFormValues(formStateFromCourse(savedCourse));
+        setLastSavedAt(savedCourse.updatedAt);
+        setIsDirty(false);
+        setFeedback({ type: "success", message: "Course details saved successfully." });
+      } catch (error) {
+        setFeedback({
+          type: "error",
+          message: error instanceof Error ? error.message : "Something went wrong while saving the course.",
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [focusFirstError, formValues, persistedCourse, validateForm],
+  );
+
+  const handleDelete = useCallback(() => {
+    setShowDeleteModal(true);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!persistedCourse?.id) {
+      setShowDeleteModal(false);
+      return;
+    }
+
+    setIsDeleting(true);
+    setFeedback(null);
+
+    try {
+      await removeCourse(persistedCourse.id);
+      setFeedback({ type: "info", message: "Course deleted. You can start a new draft now." });
+      setPersistedCourse(undefined);
+      setFormValues(emptyCourseForm);
+      setErrors({});
+      setTouched({});
+      setFormSubmitted(false);
+      setIsDirty(false);
+      setLastSavedAt(null);
+    } catch (error) {
+      setFeedback({
+        type: "error",
+        message: error instanceof Error ? error.message : "Failed to delete the course. Please try again.",
+      });
+    } finally {
+      setIsDeleting(false);
+      setShowDeleteModal(false);
+    }
+  }, [persistedCourse]);
+
+  const cancelDelete = useCallback(() => {
+    setShowDeleteModal(false);
+  }, []);
+
+  const shouldShowError = useCallback(
+    (field: FieldName) => Boolean(errors[field] && (touched[field] || formSubmitted)),
+    [errors, formSubmitted, touched],
+  );
+
+  const canDelete = Boolean(persistedCourse?.id);
+
+  return (
+    <section className="flex h-full flex-col">
+      <header className="mb-8">
+        <p className="text-3xl font-semibold text-black sm:text-4xl">{heading}</p>
+        <p className="mt-2 text-base text-black/70 sm:text-lg">{subheading}</p>
+      </header>
+
+      {feedback && (
+        <div
+          ref={feedbackRef}
+          role={feedback.type === "error" ? "alert" : "status"}
+          tabIndex={-1}
+          className={`mb-6 rounded-xl px-4 py-3 text-sm sm:text-base ${feedbackStyles[feedback.type]}`}
+          aria-live={feedback.type === "error" ? "assertive" : "polite"}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <form className="flex flex-1 flex-col" onSubmit={handleSubmit} noValidate>
+        <div className="grid gap-6">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="title" className="text-lg font-medium text-black">
+              Course Title
+            </label>
+            <Input
+              id="title"
+              name="title"
+              value={formValues.title}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder="Enter course title"
+              required
+              ref={fieldRefs.title}
+              errorMessage={shouldShowError("title") ? errors.title : undefined}
+            />
+            {shouldShowError("title") && (
+              <p id="title-error" className="text-sm text-red-600" role="alert">
+                {errors.title}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="instructor" className="text-lg font-medium text-black">
+              Instructor
+            </label>
+            <Input
+              id="instructor"
+              name="instructor"
+              value={formValues.instructor}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder="Enter instructor name"
+              required
+              ref={fieldRefs.instructor}
+              errorMessage={shouldShowError("instructor") ? errors.instructor : undefined}
+            />
+            {shouldShowError("instructor") && (
+              <p id="instructor-error" className="text-sm text-red-600" role="alert">
+                {errors.instructor}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="price" className="text-lg font-medium text-black">
+              Price
+            </label>
+            <Input
+              id="price"
+              name="price"
+              inputMode="decimal"
+              value={formValues.price}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder="0.00"
+              required
+              ref={fieldRefs.price}
+              errorMessage={shouldShowError("price") ? errors.price : undefined}
+            />
+            {shouldShowError("price") && (
+              <p id="price-error" className="text-sm text-red-600" role="alert">
+                {errors.price}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="category" className="text-lg font-medium text-black">
+              Category
+            </label>
+            <Input
+              id="category"
+              name="category"
+              value={formValues.category}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder="e.g. STEM"
+              required
+              ref={fieldRefs.category}
+              errorMessage={shouldShowError("category") ? errors.category : undefined}
+            />
+            {shouldShowError("category") && (
+              <p id="category-error" className="text-sm text-red-600" role="alert">
+                {errors.category}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="description" className="text-lg font-medium text-black">
+              Description
+            </label>
+            <Textarea
+              id="description"
+              name="description"
+              value={formValues.description}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder="Provide a brief overview of the course."
+              rows={5}
+              required
+              ref={fieldRefs.description}
+              errorMessage={shouldShowError("description") ? errors.description : undefined}
+            />
+            {shouldShowError("description") && (
+              <p id="description-error" className="text-sm text-red-600" role="alert">
+                {errors.description}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="syllabus" className="text-lg font-medium text-black">
+              Syllabus
+            </label>
+            <Textarea
+              id="syllabus"
+              name="syllabus"
+              value={formValues.syllabus}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder="Outline the syllabus or upload details."
+              rows={8}
+              required
+              ref={fieldRefs.syllabus}
+              errorMessage={shouldShowError("syllabus") ? errors.syllabus : undefined}
+            />
+            {shouldShowError("syllabus") && (
+              <p id="syllabus-error" className="text-sm text-red-600" role="alert">
+                {errors.syllabus}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-black/60" aria-live="polite">
+            {helperText}
+          </p>
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            {canDelete && (
+              <ActionButton
+                type="button"
+                variant="danger"
+                onClick={handleDelete}
+                isLoading={isDeleting}
+                loadingLabel="Deleting"
+              >
+                Delete
+              </ActionButton>
+            )}
+            <ActionButton type="submit" isLoading={isSaving} loadingLabel="Saving">
+              Save
+            </ActionButton>
+          </div>
+        </div>
+      </form>
+
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="delete-course-title"
+            aria-describedby="delete-course-description"
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-lg"
+          >
+            <h2 id="delete-course-title" className="text-xl font-semibold text-black">
+              Delete this course?
+            </h2>
+            <p id="delete-course-description" className="mt-2 text-sm text-black/70">
+              This action cannot be undone. Deleting the course will remove all related content from the platform.
+            </p>
+            <div className="mt-6 flex justify-end gap-3">
+              <ActionButton
+                ref={cancelDeleteRef}
+                type="button"
+                variant="ghost"
+                onClick={cancelDelete}
+                disabled={isDeleting}
+              >
+                Cancel
+              </ActionButton>
+              <ActionButton
+                type="button"
+                variant="danger"
+                onClick={confirmDelete}
+                isLoading={isDeleting}
+                loadingLabel="Deleting"
+              >
+                Delete
+              </ActionButton>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/app/(admin)/courses/_lib/course-actions.ts
+++ b/src/app/(admin)/courses/_lib/course-actions.ts
@@ -1,0 +1,84 @@
+import { buildCoursePayload, Course, CoursePayload, generateCourseId } from "../_types/course";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface PersistCourseOptions {
+  autoSave?: boolean;
+  signal?: AbortSignal;
+}
+
+export const persistCourse = async (
+  payload: CoursePayload,
+  options: PersistCourseOptions = {},
+): Promise<Course> => {
+  const { autoSave = false, signal } = options;
+
+  if (Number.isNaN(payload.price)) {
+    throw new Error("Price must be a valid number.");
+  }
+
+  await delay(autoSave ? 400 : 800);
+
+  if (signal?.aborted) {
+    throw new DOMException("Request aborted", "AbortError");
+  }
+
+  const now = new Date().toISOString();
+
+  return {
+    ...payload,
+    id: payload.id ?? generateCourseId(),
+    price: Number(payload.price),
+    createdAt: payload.createdAt ?? now,
+    updatedAt: now,
+  };
+};
+
+export const removeCourse = async (courseId: string, signal?: AbortSignal): Promise<void> => {
+  if (!courseId) {
+    throw new Error("Course id is required to delete a course.");
+  }
+
+  await delay(700);
+
+  if (signal?.aborted) {
+    throw new DOMException("Request aborted", "AbortError");
+  }
+};
+
+export const fetchCourseById = async (courseId: string): Promise<Course | null> => {
+  if (!courseId) {
+    return null;
+  }
+
+  await delay(400);
+
+  const seeded: Course = {
+    id: courseId,
+    title: "Advanced Mathematics",
+    instructor: "Dr. Jane Doe",
+    price: 199.99,
+    category: "STEM",
+    description:
+      "Deep dive into advanced calculus, linear algebra, and differential equations tailored for competitive exams.",
+    syllabus:
+      "Week 1: Multivariable Calculus\nWeek 2: Differential Equations\nWeek 3: Linear Algebra\nWeek 4: Exam Strategy & Practice.",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+  };
+
+  return seeded;
+};
+
+export const createDraftPayload = (course?: Course) =>
+  buildCoursePayload(
+    {
+      title: course?.title ?? "",
+      instructor: course?.instructor ?? "",
+      price: course ? course.price.toString() : "",
+      category: course?.category ?? "",
+      description: course?.description ?? "",
+      syllabus: course?.syllabus ?? "",
+    },
+    course,
+  );

--- a/src/app/(admin)/courses/_types/course.ts
+++ b/src/app/(admin)/courses/_types/course.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+
+export const courseFormSchema = z.object({
+  title: z.string().trim().min(1, "Course title is required."),
+  instructor: z.string().trim().min(1, "Instructor name is required."),
+  price: z
+    .string()
+    .trim()
+    .min(1, "Price is required.")
+    .refine((value) => /^\d+(\.\d{1,2})?$/.test(value), "Enter a valid price (numbers only, up to two decimals)."),
+  category: z.string().trim().min(1, "Category is required."),
+  description: z
+    .string()
+    .trim()
+    .min(10, "Description should be at least 10 characters long."),
+  syllabus: z
+    .string()
+    .trim()
+    .min(10, "Syllabus should be at least 10 characters long."),
+});
+
+export type CourseFormState = z.infer<typeof courseFormSchema>;
+
+export interface Course {
+  id: string;
+  title: string;
+  instructor: string;
+  price: number;
+  category: string;
+  description: string;
+  syllabus: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CoursePayload = Omit<Course, "createdAt" | "updatedAt"> & {
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export const emptyCourseForm: CourseFormState = {
+  title: "",
+  instructor: "",
+  price: "",
+  category: "",
+  description: "",
+  syllabus: "",
+};
+
+export const formStateFromCourse = (course: Course): CourseFormState => ({
+  title: course.title ?? "",
+  instructor: course.instructor ?? "",
+  price: Number.isFinite(course.price) ? course.price.toString() : "",
+  category: course.category ?? "",
+  description: course.description ?? "",
+  syllabus: course.syllabus ?? "",
+});
+
+export const generateCourseId = (): string => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `course_${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export const buildCoursePayload = (
+  form: CourseFormState,
+  course?: Course,
+  overrides?: Partial<CoursePayload>,
+): CoursePayload => {
+  const now = new Date().toISOString();
+  const base: CoursePayload = {
+    id: course?.id ?? generateCourseId(),
+    title: form.title.trim(),
+    instructor: form.instructor.trim(),
+    price: Number.parseFloat(form.price.trim()),
+    category: form.category.trim(),
+    description: form.description.trim(),
+    syllabus: form.syllabus.trim(),
+    createdAt: course?.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  return { ...base, ...overrides };
+};

--- a/src/components/form/action-button.tsx
+++ b/src/components/form/action-button.tsx
@@ -1,0 +1,39 @@
+import { Loader2 } from "lucide-react";
+import { forwardRef } from "react";
+import { cn } from "../../lib/utils";
+
+export interface ActionButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  isLoading?: boolean;
+  loadingLabel?: string;
+  variant?: "solid" | "outline" | "ghost" | "danger";
+}
+
+const baseStyles =
+  "inline-flex items-center justify-center gap-2 rounded-lg px-6 py-3 text-base font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60";
+
+const variantStyles: Record<NonNullable<ActionButtonProps["variant"]>, string> = {
+  solid: "bg-[#dd7c5e] text-white hover:bg-[#c46b50] focus-visible:outline-[#dd7c5e]",
+  danger: "bg-[#dd7c5e] text-white hover:bg-[#c46b50] focus-visible:outline-[#dd7c5e]",
+  outline:
+    "border border-[#dd7c5e] text-[#dd7c5e] hover:bg-[#dd7c5e]/10 focus-visible:outline-[#dd7c5e]",
+  ghost: "text-[#dd7c5e] hover:bg-[#dd7c5e]/10 focus-visible:outline-[#dd7c5e]",
+};
+
+export const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(function ActionButton(
+  { className, isLoading, loadingLabel, children, disabled, variant = "solid", ...props },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      className={cn(baseStyles, variantStyles[variant], className)}
+      disabled={disabled || isLoading}
+      {...props}
+    >
+      {isLoading && (
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+      )}
+      <span>{isLoading ? loadingLabel ?? "Processing" : children}</span>
+    </button>
+  );
+});

--- a/src/components/form/input.tsx
+++ b/src/components/form/input.tsx
@@ -1,0 +1,25 @@
+import { forwardRef } from "react";
+import { cn } from "../../lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  errorMessage?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, errorMessage, ...props },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        "w-full rounded-lg border border-black/20 bg-[#bdd0d2] px-4 py-3 text-base text-black placeholder:text-black/50 focus:border-[#33a1cd] focus:outline-none focus:ring-2 focus:ring-[#33a1cd] disabled:cursor-not-allowed disabled:opacity-50",
+        errorMessage && "border-red-500 focus:border-red-500 focus:ring-red-500",
+        className,
+      )}
+      aria-invalid={Boolean(errorMessage)}
+      aria-describedby={errorMessage ? `${props.id ?? props.name}-error` : props["aria-describedby"]}
+      {...props}
+    />
+  );
+});

--- a/src/components/form/textarea.tsx
+++ b/src/components/form/textarea.tsx
@@ -1,0 +1,25 @@
+import { forwardRef } from "react";
+import { cn } from "../../lib/utils";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  errorMessage?: string;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, errorMessage, ...props },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "w-full rounded-lg border border-black/20 bg-[#bdd0d2] px-4 py-3 text-base text-black placeholder:text-black/50 focus:border-[#33a1cd] focus:outline-none focus:ring-2 focus:ring-[#33a1cd] disabled:cursor-not-allowed disabled:opacity-50",
+        errorMessage && "border-red-500 focus:border-red-500 focus:ring-red-500",
+        className,
+      )}
+      aria-invalid={Boolean(errorMessage)}
+      aria-describedby={errorMessage ? `${props.id ?? props.name}-error` : props["aria-describedby"]}
+      {...props}
+    />
+  );
+});


### PR DESCRIPTION
## Summary
- add an admin course details page wired to the dashboard layout and dynamic routing
- implement a client CourseForm with validation, autosave, feedback, and delete confirmation states
- introduce shared form controls, course types, and mock data actions to support the workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d068d9c288832a9ca75ed10c7d57f4