### PR TITLE
feat: add tutor management dashboard screen

### DIFF
--- a/src/screens/TutorManagement/TutorManagementPage.tsx
+++ b/src/screens/TutorManagement/TutorManagementPage.tsx
@@ -1,0 +1,658 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronRight, Home, UserPlus } from "lucide-react";
+
+import { AdminSidebar } from "./components/AdminSidebar";
+import { BulkActionsBar } from "./components/BulkActionsBar";
+import { ConfirmDialog } from "./components/ConfirmDialog";
+import { Toast } from "./components/Toast";
+import { TutorActions } from "./components/TutorActions";
+import { TutorForm } from "./components/TutorForm";
+import { TutorOverviewCard } from "./components/TutorOverviewCard";
+import { TutorsList } from "./components/TutorsList";
+import type { Tutor, TutorFormData, TutorOverview, TutorStatusFilter } from "./types";
+
+const initialTutors: Tutor[] = [
+  {
+    id: "tutor-1",
+    name: "Alice Johnson",
+    email: "alice.johnson@example.com",
+    specialization: ["Mathematics", "Physics"],
+    coursesAssigned: ["Calculus I", "Quantum Mechanics"],
+    joinedDate: new Date("2023-02-14"),
+    status: "active",
+    lastActiveAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2),
+    feedbackScore: 4.8,
+    notes: "Prefers asynchronous updates and weekly summaries.",
+  },
+  {
+    id: "tutor-2",
+    name: "Benjamin Lee",
+    email: "ben.lee@example.com",
+    specialization: ["Chemistry", "Biology"],
+    coursesAssigned: ["Organic Chemistry", "Molecular Biology"],
+    joinedDate: new Date("2022-11-03"),
+    status: "pending",
+    lastActiveAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 12),
+    feedbackScore: 4.4,
+    notes: "Pending onboarding documents.",
+  },
+  {
+    id: "tutor-3",
+    name: "Cynthia Patel",
+    email: "cynthia.patel@example.com",
+    specialization: ["Computer Science", "Data Science"],
+    coursesAssigned: ["Algorithms", "Intro to Machine Learning"],
+    joinedDate: new Date("2021-09-22"),
+    status: "active",
+    lastActiveAt: new Date(Date.now() - 1000 * 60 * 60 * 8),
+    feedbackScore: 4.9,
+    notes: "Great at mentoring junior tutors.",
+  },
+  {
+    id: "tutor-4",
+    name: "Diego Martinez",
+    email: "diego.martinez@example.com",
+    specialization: ["History", "Sociology"],
+    coursesAssigned: ["World History", "Sociology of Education"],
+    joinedDate: new Date("2020-01-12"),
+    status: "inactive",
+    lastActiveAt: new Date("2023-06-16"),
+    feedbackScore: 4.2,
+    notes: "On sabbatical leave until Q2.",
+  },
+  {
+    id: "tutor-5",
+    name: "Emily Carter",
+    email: "emily.carter@example.com",
+    specialization: ["English Literature", "Creative Writing"],
+    coursesAssigned: ["Advanced Composition", "Literary Analysis"],
+    joinedDate: new Date("2023-07-08"),
+    status: "active",
+    lastActiveAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5),
+    feedbackScore: 4.7,
+    notes: "Interested in launching a writing workshop.",
+  },
+];
+
+const emptyForm: TutorFormData = {
+  name: "",
+  email: "",
+  specialization: [],
+  coursesAssigned: [],
+  notes: "",
+};
+
+type ManagementMode = "overview" | "edit";
+
+const sortStrings = (values: string[] = []): string[] => [...values].sort((a, b) => a.localeCompare(b));
+
+const arraysEqual = (a: string[] = [], b: string[] = []): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  const sortedA = sortStrings(a);
+  const sortedB = sortStrings(b);
+
+  return sortedA.every((value, index) => sortedB[index] === value);
+};
+
+const computeOverview = (tutors: Tutor[]): TutorOverview => ({
+  totalTutors: tutors.length,
+  activeTutors: tutors.filter((tutor) => tutor.status === "active").length,
+  pendingInvites: tutors.filter((tutor) => tutor.status === "pending").length,
+});
+
+export const TutorManagementPage: React.FC = () => {
+  const [tutors, setTutors] = useState<Tutor[]>(initialTutors);
+  const [mode, setMode] = useState<ManagementMode>("overview");
+  const [selectedTutorId, setSelectedTutorId] = useState<string | null>(initialTutors[0]?.id ?? null);
+  const [formData, setFormData] = useState<TutorFormData>(initialTutors[0] ? {
+    name: initialTutors[0].name,
+    email: initialTutors[0].email,
+    specialization: initialTutors[0].specialization ?? [],
+    coursesAssigned: initialTutors[0].coursesAssigned ?? [],
+    notes: initialTutors[0].notes ?? "",
+  } : emptyForm);
+  const [status, setStatus] = useState<Tutor["status"]>(initialTutors[0]?.status ?? "active");
+  const [formErrors, setFormErrors] = useState<Partial<Record<keyof TutorFormData, string>>>({});
+  const [selectedTutorIds, setSelectedTutorIds] = useState<string[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [statusFilter, setStatusFilter] = useState<TutorStatusFilter>("all");
+  const [specializationFilter, setSpecializationFilter] = useState<string>("all");
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [toastState, setToastState] = useState<{ message: string; type: "success" | "error" | "info" } | null>(null);
+  const [autoSaveState, setAutoSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const listSectionRef = useRef<HTMLDivElement | null>(null);
+
+  const selectedTutor = useMemo(
+    () => tutors.find((tutor) => tutor.id === selectedTutorId) ?? null,
+    [selectedTutorId, tutors],
+  );
+
+  const overview = useMemo(() => computeOverview(tutors), [tutors]);
+
+  const availableSpecializations = useMemo(() => {
+    const values = new Set<string>();
+    tutors.forEach((tutor) => (tutor.specialization ?? []).forEach((item) => values.add(item)));
+    return Array.from(values).sort((a, b) => a.localeCompare(b));
+  }, [tutors]);
+
+  const availableCourses = useMemo(() => {
+    const values = new Set<string>();
+    tutors.forEach((tutor) => (tutor.coursesAssigned ?? []).forEach((course) => values.add(course)));
+    return Array.from(values).sort((a, b) => a.localeCompare(b));
+  }, [tutors]);
+
+  const filteredTutors = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return tutors
+      .filter((tutor) => {
+        const matchesSearch =
+          normalizedSearch.length === 0 ||
+          [
+            tutor.name,
+            tutor.email,
+            ...(tutor.specialization ?? []),
+            ...(tutor.coursesAssigned ?? []),
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(normalizedSearch);
+
+        const matchesStatus = statusFilter === "all" || tutor.status === statusFilter;
+        const matchesSpecialization =
+          specializationFilter === "all" || (tutor.specialization ?? []).includes(specializationFilter);
+
+        return matchesSearch && matchesStatus && matchesSpecialization;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [searchTerm, specializationFilter, statusFilter, tutors]);
+
+  const isCreating = selectedTutorId === null;
+
+  const hasChanges = useMemo(() => {
+    if (isCreating) {
+      return Boolean(
+        formData.name.trim() ||
+          formData.email.trim() ||
+          (formData.specialization?.length ?? 0) > 0 ||
+          (formData.coursesAssigned?.length ?? 0) > 0 ||
+          formData.notes?.trim(),
+      );
+    }
+
+    if (!selectedTutor) {
+      return false;
+    }
+
+    return (
+      formData.name.trim() !== selectedTutor.name.trim() ||
+      formData.email.trim().toLowerCase() !== selectedTutor.email.trim().toLowerCase() ||
+      !arraysEqual(formData.specialization ?? [], selectedTutor.specialization ?? []) ||
+      !arraysEqual(formData.coursesAssigned ?? [], selectedTutor.coursesAssigned ?? []) ||
+      (formData.notes ?? "").trim() !== (selectedTutor.notes ?? "").trim() ||
+      status !== selectedTutor.status
+    );
+  }, [formData, isCreating, selectedTutor, status]);
+
+  useEffect(() => {
+    if (!selectedTutor && tutors.length > 0 && !isCreating) {
+      setSelectedTutorId(tutors[0].id);
+    }
+  }, [isCreating, selectedTutor, tutors]);
+
+  useEffect(() => {
+    setSelectedTutorIds((ids) => ids.filter((id) => tutors.some((tutor) => tutor.id === id)));
+  }, [tutors]);
+
+  useEffect(() => {
+    if (!selectedTutor) {
+      setFormData(emptyForm);
+      setStatus("active");
+      setAutoSaveState("idle");
+      return;
+    }
+
+    setFormData({
+      name: selectedTutor.name,
+      email: selectedTutor.email,
+      specialization: [...(selectedTutor.specialization ?? [])],
+      coursesAssigned: [...(selectedTutor.coursesAssigned ?? [])],
+      notes: selectedTutor.notes ?? "",
+    });
+    setStatus(selectedTutor.status);
+    setFormErrors({});
+    setAutoSaveState("idle");
+  }, [selectedTutor]);
+
+  useEffect(() => {
+    if (!selectedTutor || !hasChanges || isSaving || isCreating) {
+      setAutoSaveState("idle");
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+        autoSaveTimerRef.current = null;
+      }
+      return;
+    }
+
+    setAutoSaveState("saving");
+
+    if (autoSaveTimerRef.current) {
+      clearTimeout(autoSaveTimerRef.current);
+    }
+
+    autoSaveTimerRef.current = setTimeout(() => {
+      setAutoSaveState("saved");
+      autoSaveTimerRef.current = null;
+    }, 1200);
+
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+        autoSaveTimerRef.current = null;
+      }
+    };
+  }, [hasChanges, isCreating, isSaving, selectedTutor]);
+
+  useEffect(() => {
+    if (!toastState) {
+      return;
+    }
+
+    const timer = setTimeout(() => setToastState(null), 4000);
+    return () => clearTimeout(timer);
+  }, [toastState]);
+
+  const handleFieldChange = (field: keyof TutorFormData, value: string | string[]) => {
+    setFormData((previous) => ({
+      ...previous,
+      [field]: Array.isArray(value) ? value : value,
+    }));
+  };
+
+  const handleAddSpecialization = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    setFormData((previous) => {
+      const current = previous.specialization ?? [];
+      if (current.includes(trimmed)) {
+        return previous;
+      }
+      return { ...previous, specialization: [...current, trimmed] };
+    });
+  };
+
+  const handleRemoveSpecialization = (value: string) => {
+    setFormData((previous) => ({
+      ...previous,
+      specialization: (previous.specialization ?? []).filter((item) => item !== value),
+    }));
+  };
+
+  const handleAddCourse = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    setFormData((previous) => {
+      const current = previous.coursesAssigned ?? [];
+      if (current.includes(trimmed)) {
+        return previous;
+      }
+      return { ...previous, coursesAssigned: [...current, trimmed] };
+    });
+  };
+
+  const handleRemoveCourse = (value: string) => {
+    setFormData((previous) => ({
+      ...previous,
+      coursesAssigned: (previous.coursesAssigned ?? []).filter((item) => item !== value),
+    }));
+  };
+
+  const handleSelectTutor = (id: string) => {
+    setSelectedTutorId(id);
+    setMode("edit");
+    setFormErrors({});
+    setTimeout(() => {
+      document.getElementById("tutor-form-section")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
+  };
+
+  const handleToggleSelectTutor = (id: string) => {
+    setSelectedTutorIds((previous) =>
+      previous.includes(id) ? previous.filter((selectedId) => selectedId !== id) : [...previous, id],
+    );
+  };
+
+  const handleToggleSelectAll = (selectAll: boolean) => {
+    if (!selectAll) {
+      setSelectedTutorIds((previous) => previous.filter((id) => !filteredTutors.some((tutor) => tutor.id === id)));
+      return;
+    }
+
+    setSelectedTutorIds((previous) => {
+      const combined = new Set([...previous, ...filteredTutors.map((tutor) => tutor.id)]);
+      return Array.from(combined);
+    });
+  };
+
+  const handleViewDetails = () => {
+    setMode("overview");
+    if (listSectionRef.current) {
+      listSectionRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
+
+  const handleInviteTutor = () => {
+    setToastState({ message: "Invitation email sent to pending tutors.", type: "info" });
+  };
+
+  const validateForm = (): boolean => {
+    const errors: Partial<Record<keyof TutorFormData, string>> = {};
+
+    if (!formData.name.trim()) {
+      errors.name = "Tutor name is required.";
+    }
+
+    if (!formData.email.trim()) {
+      errors.email = "Email address is required.";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email.trim())) {
+      errors.email = "Enter a valid email address.";
+    }
+
+    setFormErrors(errors);
+
+    if (Object.keys(errors).length > 0) {
+      setToastState({ message: "Please resolve validation errors before saving.", type: "error" });
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleSave = () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSaving(true);
+
+    setTimeout(() => {
+      if (isCreating) {
+        const newTutor: Tutor = {
+          id: `tutor-${Date.now()}`,
+          name: formData.name.trim(),
+          email: formData.email.trim().toLowerCase(),
+          specialization: [...(formData.specialization ?? [])],
+          coursesAssigned: [...(formData.coursesAssigned ?? [])],
+          joinedDate: new Date(),
+          status,
+          lastActiveAt: status === "active" ? new Date() : undefined,
+          notes: formData.notes?.trim() ?? "",
+        };
+
+        setTutors((previous) => [newTutor, ...previous]);
+        setSelectedTutorId(newTutor.id);
+        setMode("edit");
+        setToastState({ message: "Tutor created successfully.", type: "success" });
+      } else if (selectedTutorId) {
+        setTutors((previous) =>
+          previous.map((tutor) =>
+            tutor.id === selectedTutorId
+              ? {
+                  ...tutor,
+                  name: formData.name.trim(),
+                  email: formData.email.trim().toLowerCase(),
+                  specialization: [...(formData.specialization ?? [])],
+                  coursesAssigned: [...(formData.coursesAssigned ?? [])],
+                  status,
+                  lastActiveAt: status === "active" ? new Date() : tutor.lastActiveAt,
+                  notes: formData.notes?.trim() ?? "",
+                }
+              : tutor,
+          ),
+        );
+        setToastState({ message: "Tutor profile updated.", type: "success" });
+      }
+
+      setIsSaving(false);
+      setAutoSaveState("saved");
+    }, 900);
+  };
+
+  const handleDelete = () => {
+    if (!selectedTutorId) {
+      setFormData(emptyForm);
+      setStatus("active");
+      setMode("overview");
+      return;
+    }
+
+    setShowDeleteDialog(true);
+  };
+
+  const confirmDelete = () => {
+    if (!selectedTutorId) {
+      return;
+    }
+
+    const tutorToRemove = selectedTutorId;
+    setIsDeleting(true);
+
+    setTimeout(() => {
+      let nextTutorId: string | null = null;
+
+      setTutors((previous) => {
+        const updated = previous.filter((tutor) => tutor.id !== tutorToRemove);
+        nextTutorId = updated[0]?.id ?? null;
+        return updated;
+      });
+
+      setSelectedTutorIds((previous) => previous.filter((id) => id !== tutorToRemove));
+      setSelectedTutorId(nextTutorId);
+      setMode("overview");
+      setToastState({ message: "Tutor removed from the roster.", type: "info" });
+      setIsDeleting(false);
+      setShowDeleteDialog(false);
+    }, 900);
+  };
+
+  const handleBulkActivate = () => {
+    setTutors((previous) =>
+      previous.map((tutor) =>
+        selectedTutorIds.includes(tutor.id) ? { ...tutor, status: "active", lastActiveAt: new Date() } : tutor,
+      ),
+    );
+    setToastState({ message: "Selected tutors marked as active.", type: "success" });
+  };
+
+  const handleBulkDeactivate = () => {
+    setTutors((previous) =>
+      previous.map((tutor) =>
+        selectedTutorIds.includes(tutor.id) ? { ...tutor, status: "inactive" } : tutor,
+      ),
+    );
+    setToastState({ message: "Selected tutors marked as inactive.", type: "info" });
+  };
+
+  const handleBulkInvite = () => {
+    setToastState({ message: "Invitation emails queued for selected tutors.", type: "info" });
+  };
+
+  const handleBulkPermissions = () => {
+    setToastState({ message: "Permissions update scheduled for selected tutors.", type: "success" });
+  };
+
+  const clearSelection = () => setSelectedTutorIds([]);
+
+  const handleCreateTutor = () => {
+    setSelectedTutorId(null);
+    setFormData(emptyForm);
+    setStatus("pending");
+    setMode("edit");
+    setFormErrors({});
+    document.getElementById("tutor-form-section")?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  return (
+    <div className="min-h-screen w-full bg-white">
+      <div className="mx-auto flex w-full max-w-[1440px] gap-6 bg-[#33a1cd]/10 p-4 md:p-6">
+        <AdminSidebar activeItem="tutors" />
+
+        <main className="flex-1 rounded-3xl bg-[#f3f3f3] p-4 md:p-8">
+          <div className="flex flex-col gap-6">
+            <header className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h1 className="text-3xl font-semibold text-gray-900">Tutor Details</h1>
+                  <nav aria-label="Breadcrumb" className="mt-2 flex items-center gap-2 text-sm text-gray-500">
+                    <Home className="h-4 w-4" aria-hidden="true" />
+                    <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                    <span>Dashboard</span>
+                    <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                    <span className="font-semibold text-gray-700">Tutor Management</span>
+                  </nav>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={handleCreateTutor}
+                  className="inline-flex items-center gap-2 rounded-lg bg-[#dd7c5e] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#dd7c5e]/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+                >
+                  <UserPlus className="h-4 w-4" aria-hidden="true" />
+                  Add tutor
+                </button>
+              </div>
+
+              <div className="flex gap-2 md:hidden">
+                <button
+                  type="button"
+                  onClick={() => setMode("overview")}
+                  className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition ${
+                    mode === "overview"
+                      ? "bg-[#dd7c5e] text-white"
+                      : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                  }`}
+                >
+                  Tutors List
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMode("edit")}
+                  className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition ${
+                    mode === "edit"
+                      ? "bg-[#dd7c5e] text-white"
+                      : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                  }`}
+                  disabled={!selectedTutor && !isCreating}
+                >
+                  Tutor Form
+                </button>
+              </div>
+            </header>
+
+            <TutorOverviewCard
+              overview={overview}
+              onViewDetails={handleViewDetails}
+              onInviteTutor={handleInviteTutor}
+            />
+
+            <BulkActionsBar
+              selectedCount={selectedTutorIds.length}
+              onSendInvite={handleBulkInvite}
+              onActivate={handleBulkActivate}
+              onDeactivate={handleBulkDeactivate}
+              onAssignPermissions={handleBulkPermissions}
+              onClearSelection={clearSelection}
+            />
+
+            <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+              <div ref={listSectionRef} className={mode === "edit" ? "md:block hidden" : "block"}>
+                <TutorsList
+                  tutors={filteredTutors}
+                  searchTerm={searchTerm}
+                  onSearchTermChange={setSearchTerm}
+                  statusFilter={statusFilter}
+                  onStatusFilterChange={setStatusFilter}
+                  specializationFilter={specializationFilter}
+                  onSpecializationFilterChange={setSpecializationFilter}
+                  selectedTutorIds={selectedTutorIds}
+                  onToggleSelectTutor={handleToggleSelectTutor}
+                  onToggleSelectAll={handleToggleSelectAll}
+                  onViewTutor={handleSelectTutor}
+                  availableSpecializations={availableSpecializations}
+                />
+              </div>
+
+              <section
+                id="tutor-form-section"
+                className={mode === "overview" ? "md:block hidden" : "block"}
+              >
+                <TutorForm
+                  tutor={selectedTutor}
+                  formData={formData}
+                  errors={formErrors}
+                  status={status}
+                  onFieldChange={handleFieldChange}
+                  onStatusChange={setStatus}
+                  onAddSpecialization={handleAddSpecialization}
+                  onRemoveSpecialization={handleRemoveSpecialization}
+                  onAddCourse={handleAddCourse}
+                  onRemoveCourse={handleRemoveCourse}
+                  availableSpecializations={availableSpecializations}
+                  availableCourses={availableCourses}
+                  isSaving={isSaving}
+                  autoSaveState={isCreating ? "idle" : autoSaveState}
+                />
+
+                <TutorActions
+                  onSave={handleSave}
+                  onDelete={handleDelete}
+                  onCancelEdit={isCreating ? () => setMode("overview") : undefined}
+                  isSaving={isSaving}
+                  isDeleting={isDeleting}
+                  disableSave={!hasChanges}
+                  disableDelete={isCreating}
+                />
+              </section>
+            </div>
+          </div>
+        </main>
+      </div>
+
+      <ConfirmDialog
+        open={showDeleteDialog}
+        title="Delete tutor"
+        description="This action will permanently remove the tutor from the roster and revoke their platform access. Are you sure you want to continue?"
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={confirmDelete}
+        onCancel={() => setShowDeleteDialog(false)}
+        loading={isDeleting}
+      />
+
+      {toastState && (
+        <Toast
+          message={toastState.message}
+          type={toastState.type}
+          onDismiss={() => setToastState(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TutorManagementPage;

--- a/src/screens/TutorManagement/components/AdminSidebar.tsx
+++ b/src/screens/TutorManagement/components/AdminSidebar.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { GraduationCap, LayoutDashboard, Users, Settings, LogOut, LifeBuoy } from "lucide-react";
+
+interface AdminSidebarProps {
+  activeItem?: "dashboard" | "courses" | "students" | "tutors";
+}
+
+const navigation = [
+  { key: "dashboard" as const, label: "Dashboard", icon: LayoutDashboard },
+  { key: "courses" as const, label: "Courses", icon: GraduationCap },
+  { key: "students" as const, label: "Students", icon: Users },
+  { key: "tutors" as const, label: "Tutor", icon: GraduationCap },
+];
+
+const footerLinks = [
+  { key: "settings", label: "Settings", icon: Settings },
+  { key: "logout", label: "Log out", icon: LogOut },
+  { key: "help", label: "Help", icon: LifeBuoy },
+];
+
+export const AdminSidebar: React.FC<AdminSidebarProps> = ({ activeItem = "tutors" }) => {
+  return (
+    <aside className="flex h-full w-full max-w-[260px] flex-col gap-8 rounded-3xl bg-[#33a1cd] p-6 text-white">
+      <div className="flex items-center gap-3 rounded-2xl bg-white/90 px-4 py-3 text-[#0f172a]">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#bdd0d2] text-sm font-semibold uppercase tracking-wide">
+          IV
+        </div>
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold">Infoverse</span>
+          <span className="text-xs text-[#64748b]">Admin Console</span>
+        </div>
+      </div>
+
+      <nav aria-label="Primary" className="flex flex-col gap-2">
+        {navigation.map((item) => {
+          const Icon = item.icon;
+          const isActive = item.key === activeItem;
+
+          return (
+            <a
+              key={item.key}
+              href="#"
+              aria-current={isActive ? "page" : undefined}
+              className={`flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-semibold transition ${
+                isActive
+                  ? "bg-white text-[#0f172a] shadow-lg"
+                  : "text-white/90 hover:bg-white/20"
+              }`}
+            >
+              <Icon className="h-5 w-5" aria-hidden="true" />
+              <span>{item.label}</span>
+            </a>
+          );
+        })}
+      </nav>
+
+      <div className="mt-auto grid gap-2" aria-label="Account">
+        {footerLinks.map((item) => {
+          const Icon = item.icon;
+          return (
+            <a
+              key={item.key}
+              href="#"
+              className="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/20"
+            >
+              <Icon className="h-5 w-5" aria-hidden="true" />
+              <span>{item.label}</span>
+            </a>
+          );
+        })}
+      </div>
+    </aside>
+  );
+};

--- a/src/screens/TutorManagement/components/BulkActionsBar.tsx
+++ b/src/screens/TutorManagement/components/BulkActionsBar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Mail, UserCheck, UserX, ShieldCheck } from "lucide-react";
+
+interface BulkActionsBarProps {
+  selectedCount: number;
+  onSendInvite: () => void;
+  onActivate: () => void;
+  onDeactivate: () => void;
+  onAssignPermissions: () => void;
+  onClearSelection: () => void;
+}
+
+const actions = [
+  {
+    key: "sendInvite" as const,
+    label: "Send Invite",
+    icon: Mail,
+  },
+  {
+    key: "activate" as const,
+    label: "Mark Active",
+    icon: UserCheck,
+  },
+  {
+    key: "deactivate" as const,
+    label: "Mark Inactive",
+    icon: UserX,
+  },
+  {
+    key: "permissions" as const,
+    label: "Assign Permissions",
+    icon: ShieldCheck,
+  },
+];
+
+export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
+  selectedCount,
+  onSendInvite,
+  onActivate,
+  onDeactivate,
+  onAssignPermissions,
+  onClearSelection,
+}) => {
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  const callbacks = {
+    sendInvite: onSendInvite,
+    activate: onActivate,
+    deactivate: onDeactivate,
+    permissions: onAssignPermissions,
+  } as const;
+
+  return (
+    <div className="sticky top-4 z-20 flex items-center justify-between gap-4 rounded-2xl border border-[#33a1cd]/20 bg-[#33a1cd]/10 px-4 py-3 text-sm font-semibold text-[#0f172a] shadow-sm">
+      <span>
+        {selectedCount} tutor{selectedCount > 1 ? "s" : ""} selected
+      </span>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {actions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <button
+              key={action.key}
+              type="button"
+              onClick={callbacks[action.key]}
+              className="inline-flex items-center gap-2 rounded-full border border-[#dd7c5e]/50 bg-white px-3 py-1.5 text-xs font-semibold text-[#dd7c5e] transition hover:bg-[#dd7c5e]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+            >
+              <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              {action.label}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={onClearSelection}
+          className="rounded-full border border-transparent px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:bg-white/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#33a1cd]"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/TutorManagement/components/ConfirmDialog.tsx
+++ b/src/screens/TutorManagement/components/ConfirmDialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { DialogHTMLAttributes } from "react";
+
+interface ConfirmDialogProps extends DialogHTMLAttributes<HTMLDialogElement> {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading?: boolean;
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  onCancel,
+  loading,
+}) => {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby="confirm-dialog-description"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 id="confirm-dialog-title" className="text-xl font-semibold text-gray-900">
+              {title}
+            </h2>
+            <p id="confirm-dialog-description" className="mt-2 text-sm text-gray-600">
+              {description}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-600 transition hover:border-[#33a1cd] hover:text-[#33a1cd] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#33a1cd]"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className="rounded-lg bg-[#dd7c5e] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#dd7c5e]/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? "Processing..." : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/TutorManagement/components/StatusBadge.tsx
+++ b/src/screens/TutorManagement/components/StatusBadge.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import clsx from "clsx";
+import type { Tutor } from "../types";
+
+interface StatusBadgeProps {
+  status: Tutor["status"];
+}
+
+const statusConfig: Record<Tutor["status"], { label: string; className: string }> = {
+  active: {
+    label: "Active",
+    className: "bg-emerald-100 text-emerald-700 border border-emerald-200",
+  },
+  inactive: {
+    label: "Inactive",
+    className: "bg-gray-100 text-gray-700 border border-gray-200",
+  },
+  pending: {
+    label: "Pending",
+    className: "bg-amber-100 text-amber-700 border border-amber-200",
+  },
+};
+
+export const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
+  const config = statusConfig[status];
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
+        config.className,
+      )}
+    >
+      {config.label}
+    </span>
+  );
+};

--- a/src/screens/TutorManagement/components/Toast.tsx
+++ b/src/screens/TutorManagement/components/Toast.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import clsx from "clsx";
+
+interface ToastProps {
+  message: string;
+  type?: "success" | "error" | "info";
+  onDismiss?: () => void;
+}
+
+const toastStyles: Record<NonNullable<ToastProps["type"]>, string> = {
+  success: "bg-emerald-600 text-white",
+  error: "bg-rose-600 text-white",
+  info: "bg-[#33a1cd] text-white",
+};
+
+export const Toast: React.FC<ToastProps> = ({ message, type = "info", onDismiss }) => {
+  return (
+    <div className="fixed inset-x-4 bottom-6 z-50 flex justify-center">
+      <div
+        role="status"
+        aria-live="assertive"
+        className={clsx(
+          "flex w-full max-w-md items-center justify-between gap-4 rounded-2xl px-5 py-4 shadow-lg",
+          toastStyles[type],
+        )}
+      >
+        <span className="text-sm font-semibold">{message}</span>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-full border border-white/40 px-3 py-1 text-xs font-semibold text-white/90 transition hover:bg-white/10"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/screens/TutorManagement/components/TutorActions.tsx
+++ b/src/screens/TutorManagement/components/TutorActions.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+interface TutorActionsProps {
+  onSave: () => void;
+  onDelete: () => void;
+  onCancelEdit?: () => void;
+  isSaving: boolean;
+  isDeleting: boolean;
+  disableSave: boolean;
+  disableDelete?: boolean;
+}
+
+export const TutorActions: React.FC<TutorActionsProps> = ({
+  onSave,
+  onDelete,
+  onCancelEdit,
+  isSaving,
+  isDeleting,
+  disableSave,
+  disableDelete,
+}) => {
+  return (
+    <div className="sticky bottom-0 z-10 mt-6 flex flex-wrap items-center justify-end gap-3 rounded-2xl border border-[#bdd0d2]/60 bg-white/95 p-4 shadow-md backdrop-blur">
+      {onCancelEdit && (
+        <button
+          type="button"
+          onClick={onCancelEdit}
+          className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-600 transition hover:border-[#33a1cd] hover:text-[#33a1cd] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#33a1cd]"
+        >
+          Cancel
+        </button>
+      )}
+
+      <button
+        type="button"
+        onClick={onDelete}
+        disabled={isDeleting || disableDelete}
+        className="inline-flex items-center gap-2 rounded-lg border border-[#dd7c5e] bg-white px-6 py-2 text-sm font-semibold text-[#dd7c5e] transition hover:bg-[#dd7c5e]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isDeleting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+        Delete
+      </button>
+
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={isSaving || disableSave}
+        className="inline-flex items-center gap-2 rounded-lg bg-[#dd7c5e] px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#dd7c5e]/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isSaving && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+        Save changes
+      </button>
+    </div>
+  );
+};

--- a/src/screens/TutorManagement/components/TutorForm.tsx
+++ b/src/screens/TutorManagement/components/TutorForm.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import type { Tutor, TutorFormData } from "../types";
+
+interface TutorFormProps {
+  tutor: Tutor | null;
+  formData: TutorFormData;
+  errors: Partial<Record<keyof TutorFormData, string>>;
+  status: Tutor["status"];
+  onFieldChange: (field: keyof TutorFormData, value: string | string[]) => void;
+  onStatusChange: (status: Tutor["status"]) => void;
+  onAddSpecialization: (value: string) => void;
+  onRemoveSpecialization: (value: string) => void;
+  onAddCourse: (value: string) => void;
+  onRemoveCourse: (value: string) => void;
+  availableSpecializations: string[];
+  availableCourses: string[];
+  isSaving: boolean;
+  autoSaveState: "idle" | "saving" | "saved" | "error";
+}
+
+const inputBaseClasses =
+  "block w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-[#33a1cd] focus:outline-none focus:ring-2 focus:ring-[#33a1cd]/40";
+
+export const TutorForm: React.FC<TutorFormProps> = ({
+  tutor,
+  formData,
+  errors,
+  status,
+  onFieldChange,
+  onStatusChange,
+  onAddSpecialization,
+  onRemoveSpecialization,
+  onAddCourse,
+  onRemoveCourse,
+  availableSpecializations,
+  availableCourses,
+  isSaving,
+  autoSaveState,
+}) => {
+  const handleInputChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = event.target;
+    onFieldChange(name as keyof TutorFormData, value);
+  };
+
+  const renderTagList = (
+    values: string[] | undefined,
+    onRemove: (value: string) => void,
+    label: string,
+  ) => {
+    if (!values?.length) {
+      return <p className="text-sm text-gray-500">No {label.toLowerCase()} added yet.</p>;
+    }
+
+    return (
+      <ul className="flex flex-wrap gap-2">
+        {values.map((value) => (
+          <li key={value} className="flex items-center gap-2 rounded-full bg-[#bdd0d2]/40 px-3 py-1 text-sm font-medium text-gray-700">
+            <span>{value}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(value)}
+              className="text-xs font-semibold text-[#dd7c5e] hover:text-[#dd7c5e]/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+  const renderSuggestions = (
+    suggestions: string[],
+    onSelect: (value: string) => void,
+    selected: string[] | undefined,
+  ) => {
+    if (!suggestions.length) {
+      return null;
+    }
+
+    return (
+      <div className="mt-3 flex flex-wrap gap-2">
+        {suggestions.map((suggestion) => {
+          const isSelected = selected?.includes(suggestion);
+
+          return (
+            <button
+              type="button"
+              key={suggestion}
+              onClick={() => onSelect(suggestion)}
+              className={`rounded-full border px-3 py-1 text-xs font-semibold transition ${
+                isSelected
+                  ? "border-[#dd7c5e] bg-[#dd7c5e] text-white"
+                  : "border-gray-200 text-gray-600 hover:border-[#dd7c5e] hover:text-[#dd7c5e]"
+              }`}
+            >
+              {suggestion}
+            </button>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <section
+      aria-labelledby="tutor-information-heading"
+      className="bg-white rounded-2xl shadow-sm border border-[#bdd0d2]/60 p-6 md:p-8"
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <h2
+            id="tutor-information-heading"
+            className="text-2xl md:text-3xl font-semibold text-gray-900"
+          >
+            Tutor's Information
+          </h2>
+          <p className="mt-2 text-sm text-gray-600">
+            Update personal details, teaching specializations, and assigned courses.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3 rounded-full bg-[#bdd0d2]/30 px-4 py-2 text-xs font-semibold text-gray-700">
+          <span className="inline-flex h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
+          <span>
+            {autoSaveState === "saving" && "Saving draft..."}
+            {autoSaveState === "saved" && "All changes saved"}
+            {autoSaveState === "error" && "Unable to autosave"}
+            {autoSaveState === "idle" && "Draft up to date"}
+          </span>
+        </div>
+      </div>
+
+      <form className="mt-6 grid gap-6" noValidate>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+            Tutor's Name
+            <input
+              name="name"
+              value={formData.name}
+              onChange={handleInputChange}
+              required
+              placeholder="e.g. Ada Lovelace"
+              className={`${inputBaseClasses} ${errors.name ? "border-red-400 focus:border-red-400 focus:ring-red-300" : ""}`}
+              aria-invalid={Boolean(errors.name)}
+              aria-describedby={errors.name ? "tutor-name-error" : undefined}
+            />
+            {errors.name && (
+              <span id="tutor-name-error" className="text-xs font-medium text-red-500">
+                {errors.name}
+              </span>
+            )}
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+            Email
+            <input
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleInputChange}
+              required
+              placeholder="tutor@example.com"
+              className={`${inputBaseClasses} ${errors.email ? "border-red-400 focus:border-red-400 focus:ring-red-300" : ""}`}
+              aria-invalid={Boolean(errors.email)}
+              aria-describedby={errors.email ? "tutor-email-error" : undefined}
+            />
+            {errors.email && (
+              <span id="tutor-email-error" className="text-xs font-medium text-red-500">
+                {errors.email}
+              </span>
+            )}
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-gray-700">Specializations</span>
+              <button
+                type="button"
+                onClick={() => onFieldChange("specialization", [])}
+                className="text-xs font-semibold text-[#dd7c5e] hover:text-[#dd7c5e]/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+              >
+                Clear all
+              </button>
+            </div>
+            {renderTagList(formData.specialization, onRemoveSpecialization, "Specializations")}
+            {renderSuggestions(availableSpecializations, onAddSpecialization, formData.specialization)}
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                placeholder="Add custom specialization"
+                className={inputBaseClasses}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    const value = event.currentTarget.value.trim();
+                    if (value) {
+                      onAddSpecialization(value);
+                      event.currentTarget.value = "";
+                    }
+                  }
+                }}
+              />
+              <span className="text-xs text-gray-500">Press Enter to add</span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-gray-700">Courses Assigned</span>
+              <button
+                type="button"
+                onClick={() => onFieldChange("coursesAssigned", [])}
+                className="text-xs font-semibold text-[#dd7c5e] hover:text-[#dd7c5e]/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+              >
+                Clear all
+              </button>
+            </div>
+            {renderTagList(formData.coursesAssigned, onRemoveCourse, "Courses")}
+            {renderSuggestions(availableCourses, onAddCourse, formData.coursesAssigned)}
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                placeholder="Add custom course"
+                className={inputBaseClasses}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    const value = event.currentTarget.value.trim();
+                    if (value) {
+                      onAddCourse(value);
+                      event.currentTarget.value = "";
+                    }
+                  }
+                }}
+              />
+              <span className="text-xs text-gray-500">Press Enter to add</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="flex flex-col gap-1 text-sm text-gray-700">
+            <span className="font-medium">Status</span>
+            <select
+              value={status}
+              onChange={(event) => onStatusChange(event.target.value as Tutor["status"])}
+              className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 focus:border-[#33a1cd] focus:outline-none focus:ring-2 focus:ring-[#33a1cd]/40"
+            >
+              <option value="active">Active</option>
+              <option value="inactive">Inactive</option>
+              <option value="pending">Pending</option>
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1 text-sm text-gray-700">
+            <span className="font-medium">Joined Platform</span>
+            <span className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-600">
+              {tutor
+                ? new Intl.DateTimeFormat("en", {
+                    month: "long",
+                    day: "numeric",
+                    year: "numeric",
+                  }).format(new Date(tutor.joinedDate))
+                : "—"}
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-1 text-sm text-gray-700">
+            <span className="font-medium">Last Active</span>
+            <span className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-600">
+              {tutor?.lastActiveAt
+                ? new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+                    Math.round(
+                      ((tutor.lastActiveAt.getTime ? tutor.lastActiveAt.getTime() : new Date(tutor.lastActiveAt).getTime()) -
+                        Date.now()) /
+                        (1000 * 60 * 60 * 24),
+                    ),
+                    "day",
+                  )
+                : "—"}
+            </span>
+          </div>
+        </div>
+
+        <div className="grid gap-2 text-sm text-gray-600">
+          <span className="font-semibold text-gray-700">Internal Notes</span>
+          <textarea
+            name="notes"
+            placeholder="Add notes about this tutor's onboarding progress, communication preferences, or recent feedback."
+            value={formData.notes ?? ""}
+            className={`${inputBaseClasses} min-h-[120px]`}
+            onChange={handleInputChange}
+            disabled={isSaving}
+          />
+          <p className="text-xs text-gray-500">
+            Notes are visible only to administrators. Remember to save changes to keep everyone informed.
+          </p>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/src/screens/TutorManagement/components/TutorOverviewCard.tsx
+++ b/src/screens/TutorManagement/components/TutorOverviewCard.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Users, UserCheck, MailOpen } from "lucide-react";
+import type { TutorOverview } from "../types";
+
+interface TutorOverviewCardProps {
+  overview: TutorOverview;
+  onViewDetails?: () => void;
+  onInviteTutor?: () => void;
+}
+
+const metrics = [
+  {
+    key: "totalTutors" as const,
+    label: "Total Tutors",
+    icon: Users,
+    accent: "bg-[#bdd0d2]",
+  },
+  {
+    key: "activeTutors" as const,
+    label: "Active Tutors",
+    icon: UserCheck,
+    accent: "bg-[#33a1cd]",
+  },
+  {
+    key: "pendingInvites" as const,
+    label: "Pending Invites",
+    icon: MailOpen,
+    accent: "bg-[#dd7c5e]",
+  },
+];
+
+export const TutorOverviewCard: React.FC<TutorOverviewCardProps> = ({
+  overview,
+  onViewDetails,
+  onInviteTutor,
+}) => {
+  return (
+    <section
+      aria-labelledby="tutor-overview-heading"
+      className="bg-white rounded-2xl shadow-sm border border-[#bdd0d2]/60 p-6 md:p-8 flex flex-col gap-6"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2
+            id="tutor-overview-heading"
+            className="text-2xl md:text-3xl font-semibold text-gray-900"
+          >
+            Tutors Overview
+          </h2>
+          <p className="text-sm md:text-base text-gray-600">
+            Track tutor engagement and onboarding progress at a glance.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={onInviteTutor}
+            className="rounded-lg border border-[#dd7c5e] text-[#dd7c5e] px-4 py-2 text-sm font-medium transition hover:bg-[#dd7c5e]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+          >
+            Invite Tutor
+          </button>
+          <button
+            type="button"
+            onClick={onViewDetails}
+            className="rounded-lg bg-[#dd7c5e] text-white px-4 py-2 text-sm font-semibold shadow-sm transition hover:bg-[#dd7c5e]/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+          >
+            View Tutors Details
+          </button>
+        </div>
+      </div>
+
+      <dl className="grid gap-4 md:grid-cols-3">
+        {metrics.map(({ key, label, icon: Icon, accent }) => (
+          <div
+            key={key}
+            className="flex items-center gap-4 rounded-xl border border-gray-100 bg-gray-50/80 p-4"
+          >
+            <span className={`flex h-12 w-12 items-center justify-center rounded-full ${accent} text-white`}>
+              <Icon className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <div>
+              <dt className="text-sm font-medium text-gray-600">{label}</dt>
+              <dd className="text-2xl font-semibold text-gray-900">
+                {overview[key]}
+              </dd>
+            </div>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+};

--- a/src/screens/TutorManagement/components/TutorsList.tsx
+++ b/src/screens/TutorManagement/components/TutorsList.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useMemo } from "react";
+import { Search, Filter } from "lucide-react";
+import type { Tutor, TutorStatusFilter } from "../types";
+import { StatusBadge } from "./StatusBadge";
+
+interface TutorsListProps {
+  tutors: Tutor[];
+  searchTerm: string;
+  onSearchTermChange: (value: string) => void;
+  statusFilter: TutorStatusFilter;
+  onStatusFilterChange: (value: TutorStatusFilter) => void;
+  specializationFilter: string;
+  onSpecializationFilterChange: (value: string) => void;
+  selectedTutorIds: string[];
+  onToggleSelectTutor: (id: string) => void;
+  onToggleSelectAll: (selectAll: boolean) => void;
+  onViewTutor: (id: string) => void;
+  availableSpecializations: string[];
+}
+
+export const TutorsList: React.FC<TutorsListProps> = ({
+  tutors,
+  searchTerm,
+  onSearchTermChange,
+  statusFilter,
+  onStatusFilterChange,
+  specializationFilter,
+  onSpecializationFilterChange,
+  selectedTutorIds,
+  onToggleSelectTutor,
+  onToggleSelectAll,
+  onViewTutor,
+  availableSpecializations,
+}) => {
+  const areAllSelected = useMemo(() => {
+    if (!tutors.length) {
+      return false;
+    }
+
+    return tutors.every((tutor) => selectedTutorIds.includes(tutor.id));
+  }, [selectedTutorIds, tutors]);
+
+  const quickAccessCourses = useMemo(() => {
+    const courseMap = new Map<string, string>();
+
+    tutors.forEach((tutor) => {
+      (tutor.coursesAssigned ?? []).forEach((course) => {
+        if (!courseMap.has(course)) {
+          courseMap.set(course, tutor.id);
+        }
+      });
+    });
+
+    return Array.from(courseMap.entries());
+  }, [tutors]);
+
+  return (
+    <section
+      aria-labelledby="tutors-list-heading"
+      className="bg-white rounded-2xl shadow-sm border border-[#bdd0d2]/60 p-6 md:p-8"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2
+            id="tutors-list-heading"
+            className="text-2xl md:text-3xl font-semibold text-gray-900"
+          >
+            Tutors
+          </h2>
+          <p className="text-sm md:text-base text-gray-600">
+            Manage your tutor roster, review statuses, and access detailed profiles.
+          </p>
+        </div>
+
+        <div className="flex flex-col md:flex-row gap-2 md:items-center">
+          <label className="relative flex items-center">
+            <span className="sr-only">Search tutors</span>
+            <Search className="absolute left-3 h-4 w-4 text-gray-400" aria-hidden="true" />
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => onSearchTermChange(event.target.value)}
+              placeholder="Search tutors"
+              className="w-full md:w-64 rounded-lg border border-gray-200 bg-gray-50 py-2 pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-[#33a1cd] focus:bg-white focus:outline-none focus:ring-2 focus:ring-[#33a1cd]/40"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-4 md:grid-cols-3">
+        <label className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50/80 px-4 py-3 text-sm font-medium text-gray-700">
+          <Filter className="h-5 w-5 text-gray-500" aria-hidden="true" />
+          <span>Status</span>
+          <select
+            value={statusFilter}
+            onChange={(event) => onStatusFilterChange(event.target.value as TutorStatusFilter)}
+            className="ml-auto rounded-md border border-gray-200 bg-white py-1.5 px-2 text-sm text-gray-900 focus:border-[#33a1cd] focus:outline-none focus:ring-2 focus:ring-[#33a1cd]/40"
+          >
+            <option value="all">All</option>
+            <option value="active">Active</option>
+            <option value="inactive">Inactive</option>
+            <option value="pending">Pending</option>
+          </select>
+        </label>
+
+        <label className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50/80 px-4 py-3 text-sm font-medium text-gray-700">
+          <Filter className="h-5 w-5 text-gray-500" aria-hidden="true" />
+          <span>Specialization</span>
+          <select
+            value={specializationFilter}
+            onChange={(event) => onSpecializationFilterChange(event.target.value)}
+            className="ml-auto rounded-md border border-gray-200 bg-white py-1.5 px-2 text-sm text-gray-900 focus:border-[#33a1cd] focus:outline-none focus:ring-2 focus:ring-[#33a1cd]/40"
+          >
+            <option value="all">All</option>
+            {availableSpecializations.map((specialization) => (
+              <option key={specialization} value={specialization}>
+                {specialization}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50/80 px-4 py-3 text-sm font-medium text-gray-700">
+          <Filter className="h-5 w-5 text-gray-500" aria-hidden="true" />
+          <span>Courses Assigned</span>
+          <select
+            defaultValue=""
+            onChange={(event) => {
+              const { value } = event.target;
+              if (value) {
+                onViewTutor(value);
+                event.target.value = "";
+              }
+            }}
+            className="ml-auto rounded-md border border-gray-200 bg-white py-1.5 px-2 text-sm text-gray-900 focus:border-[#33a1cd] focus:outline-none focus:ring-2 focus:ring-[#33a1cd]/40"
+          >
+            <option value="" disabled>
+              Quick access
+            </option>
+            {quickAccessCourses.map(([course, tutorId]) => (
+              <option key={course} value={tutorId}>
+                {course}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="mt-6 overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left">
+          <thead className="bg-gray-50">
+            <tr>
+              <th scope="col" className="px-4 py-3">
+                <label className="inline-flex items-center gap-2 text-sm font-medium text-gray-600">
+                  <input
+                    type="checkbox"
+                    checked={areAllSelected}
+                    onChange={(event) => onToggleSelectAll(event.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300 text-[#33a1cd] focus:ring-[#33a1cd]"
+                  />
+                  Select all
+                </label>
+              </th>
+              <th scope="col" className="px-4 py-3 text-sm font-semibold text-gray-600">
+                Tutor
+              </th>
+              <th scope="col" className="px-4 py-3 text-sm font-semibold text-gray-600">
+                Email
+              </th>
+              <th scope="col" className="px-4 py-3 text-sm font-semibold text-gray-600">
+                Specialization
+              </th>
+              <th scope="col" className="px-4 py-3 text-sm font-semibold text-gray-600">
+                Courses Assigned
+              </th>
+              <th scope="col" className="px-4 py-3 text-sm font-semibold text-gray-600">
+                Joined
+              </th>
+              <th scope="col" className="px-4 py-3 text-sm font-semibold text-gray-600">
+                Status
+              </th>
+              <th scope="col" className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {tutors.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="px-4 py-10 text-center text-sm text-gray-500">
+                  No tutors found. Adjust your filters or invite a new tutor to get started.
+                </td>
+              </tr>
+            ) : (
+              tutors.map((tutor) => {
+                const isSelected = selectedTutorIds.includes(tutor.id);
+
+                return (
+                  <tr key={tutor.id} className={isSelected ? "bg-[#33a1cd]/5" : undefined}>
+                    <td className="px-4 py-3">
+                      <input
+                        type="checkbox"
+                        aria-label={`Select ${tutor.name}`}
+                        checked={isSelected}
+                        onChange={() => onToggleSelectTutor(tutor.id)}
+                        className="h-4 w-4 rounded border-gray-300 text-[#33a1cd] focus:ring-[#33a1cd]"
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-sm font-semibold text-gray-900">
+                      <div className="flex flex-col">
+                        <span>{tutor.name}</span>
+                        {typeof tutor.feedbackScore === "number" && (
+                          <span className="text-xs text-gray-500">
+                            Feedback score: {tutor.feedbackScore.toFixed(1)} / 5
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">
+                      <a href={`mailto:${tutor.email}`} className="text-[#33a1cd] hover:underline">
+                        {tutor.email}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">
+                      {tutor.specialization?.join(", ") ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">
+                      {tutor.coursesAssigned?.join(", ") ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">
+                      {new Intl.DateTimeFormat("en", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      }).format(new Date(tutor.joinedDate))}
+                    </td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={tutor.status} />
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => onViewTutor(tutor.id)}
+                        className="rounded-lg border border-[#dd7c5e] px-3 py-1.5 text-sm font-medium text-[#dd7c5e] transition hover:bg-[#dd7c5e]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#dd7c5e]"
+                      >
+                        View details
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/src/screens/TutorManagement/index.ts
+++ b/src/screens/TutorManagement/index.ts
@@ -1,0 +1,3 @@
+export { TutorManagementPage as default } from "./TutorManagementPage";
+export * from "./TutorManagementPage";
+export * from "./types";

--- a/src/screens/TutorManagement/types.ts
+++ b/src/screens/TutorManagement/types.ts
@@ -1,0 +1,28 @@
+export interface Tutor {
+  id: string;
+  name: string;
+  email: string;
+  specialization?: string[];
+  coursesAssigned?: string[];
+  joinedDate: Date;
+  status: "active" | "inactive" | "pending";
+  lastActiveAt?: Date;
+  feedbackScore?: number;
+  notes?: string;
+}
+
+export interface TutorFormData {
+  name: string;
+  email: string;
+  specialization?: string[];
+  coursesAssigned?: string[];
+  notes?: string;
+}
+
+export interface TutorOverview {
+  totalTutors: number;
+  activeTutors: number;
+  pendingInvites: number;
+}
+
+export type TutorStatusFilter = "all" | Tutor["status"];


### PR DESCRIPTION
## Summary
- add a tutor management page with overview metrics, tutor listing, and edit form that matches the admin dashboard layout
- build reusable sidebar, list, form, bulk action, and feedback components that handle validation, filtering, selection, and CRUD workflows
- wire up state management for auto-save drafts, toast feedback, confirmation dialogs, and mock tutor data to simulate dashboard interactions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d069b7d2b4832a928f310c54b8945f