### PR TITLE
feat: add student enrollment management dashboard

### DIFF
--- a/src/app/admin/components/AdminSidebar.tsx
+++ b/src/app/admin/components/AdminSidebar.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { ElementType } from 'react';
+import { Users, GraduationCap, LayoutDashboard, UserCog, LogOut, LifeBuoy, Settings } from 'lucide-react';
+import clsx from 'clsx';
+
+interface SidebarNavItem {
+  label: string;
+  href: string;
+  icon: ElementType;
+  isActive?: boolean;
+}
+
+interface AdminSidebarProps {
+  activePath?: string;
+  className?: string;
+}
+
+const baseItems: SidebarNavItem[] = [
+  {
+    label: 'Dashboard',
+    href: '/admin',
+    icon: LayoutDashboard,
+  },
+  {
+    label: 'Courses',
+    href: '/admin/courses',
+    icon: GraduationCap,
+  },
+  {
+    label: 'Students',
+    href: '/admin/students',
+    icon: Users,
+  },
+  {
+    label: 'Tutor',
+    href: '/admin/tutors',
+    icon: UserCog,
+  },
+];
+
+const footerItems: SidebarNavItem[] = [
+  {
+    label: 'Settings',
+    href: '/admin/settings',
+    icon: Settings,
+  },
+  {
+    label: 'Log out',
+    href: '/logout',
+    icon: LogOut,
+  },
+  {
+    label: 'Help',
+    href: '/support',
+    icon: LifeBuoy,
+  },
+];
+
+export function AdminSidebar({ activePath = '/admin/students', className }: AdminSidebarProps) {
+  const items = useMemo(() => {
+    return baseItems.map((item) => ({
+      ...item,
+      isActive: activePath.startsWith(item.href),
+    }));
+  }, [activePath]);
+
+  return (
+    <aside
+      className={clsx(
+        'flex w-full max-w-xs flex-col justify-between rounded-2xl bg-[#33A1CD] p-6 text-slate-900 shadow-lg',
+        className,
+      )}
+      aria-label="Admin navigation"
+    >
+      <div>
+        <div className="mb-10 flex items-center gap-3 rounded-xl bg-white/80 px-4 py-3 text-sm font-medium uppercase tracking-wide text-slate-900 shadow">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-100 text-sm font-semibold text-slate-900">
+            IV
+          </div>
+          <span className="text-lg font-semibold">Infoverse</span>
+        </div>
+
+        <nav className="space-y-1" aria-label="Main">
+          {items.map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className={clsx(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-base font-medium transition-colors',
+                item.isActive ? 'bg-[#BDD0D2] text-slate-900' : 'text-white/90 hover:bg-white/20',
+              )}
+              aria-current={item.isActive ? 'page' : undefined}
+            >
+              <item.icon className="h-5 w-5" aria-hidden="true" />
+              <span>{item.label}</span>
+            </a>
+          ))}
+        </nav>
+      </div>
+
+      <div className="space-y-2" aria-label="Secondary">
+        {footerItems.map((item) => (
+          <a
+            key={item.href}
+            href={item.href}
+            className="flex items-center gap-3 rounded-lg px-3 py-2 text-base font-medium text-white/90 transition-colors hover:bg-white/20"
+          >
+            <item.icon className="h-5 w-5" aria-hidden="true" />
+            <span>{item.label}</span>
+          </a>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+export default AdminSidebar;

--- a/src/app/admin/components/ConfirmationDialog.tsx
+++ b/src/app/admin/components/ConfirmationDialog.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import clsx from 'clsx';
+
+interface ConfirmationDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  tone?: 'danger' | 'primary';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmationDialog({
+  open,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  tone = 'danger',
+  onConfirm,
+  onCancel,
+}: ConfirmationDialogProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        <h2 className="text-xl font-semibold text-slate-900">{title}</h2>
+        {description && <p className="mt-2 text-sm text-slate-600">{description}</p>}
+
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-full rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 sm:w-auto"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={clsx(
+              'w-full rounded-xl px-4 py-2.5 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#33A1CD] focus-visible:ring-offset-2 sm:w-auto',
+              tone === 'danger' ? 'bg-rose-600 hover:bg-rose-500' : 'bg-[#33A1CD] hover:bg-[#2a82a4]',
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmationDialog;

--- a/src/app/admin/components/Toast.tsx
+++ b/src/app/admin/components/Toast.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import clsx from 'clsx';
+
+export type ToastTone = 'success' | 'error' | 'info';
+
+interface ToastProps {
+  tone?: ToastTone;
+  message: string;
+  onDismiss?: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+const toneStyles: Record<ToastTone, string> = {
+  success: 'bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200',
+  error: 'bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-200',
+  info: 'bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-200',
+};
+
+export function Toast({ tone = 'info', message, onDismiss, actionLabel, onAction }: ToastProps) {
+  return (
+    <div className="fixed bottom-6 right-6 z-50">
+      <div className={clsx('flex items-start gap-3 rounded-2xl px-4 py-3 shadow-lg backdrop-blur', toneStyles[tone])}>
+        <span className="mt-1 inline-block h-2 w-2 rounded-full bg-current" aria-hidden="true" />
+        <p className="text-sm font-medium">{message}</p>
+        {actionLabel && onAction && (
+          <button
+            type="button"
+            onClick={onAction}
+            className="ml-auto rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide text-[#33A1CD] transition hover:text-[#2a82a4]"
+          >
+            {actionLabel}
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className={clsx(
+              'rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 transition hover:text-slate-700',
+              !actionLabel && 'ml-auto',
+            )}
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Toast;

--- a/src/app/admin/students/components/CourseEnrollmentCards.tsx
+++ b/src/app/admin/students/components/CourseEnrollmentCards.tsx
@@ -1,0 +1,139 @@
+import { TrendingUp, TrendingDown, Minus, Users2, CheckCircle2, XCircle } from 'lucide-react';
+import clsx from 'clsx';
+import type { SVGProps } from 'react';
+import type { CourseEnrollment } from '../../../../types/enrollment';
+
+interface CourseEnrollmentCardsProps {
+  courses: CourseEnrollment[];
+  selectedCourseId: string;
+  onSelectCourse: (courseId: string) => void;
+  onViewStudents: (courseId: string) => void;
+}
+
+const trendIconMap = {
+  increasing: TrendingUp,
+  stable: Minus,
+  decreasing: TrendingDown,
+};
+
+const trendColorMap = {
+  increasing: 'text-emerald-600',
+  stable: 'text-slate-500',
+  decreasing: 'text-rose-600',
+};
+
+export function CourseEnrollmentCards({
+  courses,
+  selectedCourseId,
+  onSelectCourse,
+  onViewStudents,
+}: CourseEnrollmentCardsProps) {
+  return (
+    <section aria-label="Course enrollment overview">
+      <h2 className="text-2xl font-semibold text-slate-900">Course Overview</h2>
+      <div className="mt-4 grid gap-6 md:grid-cols-2">
+        {courses.map((course) => {
+          const TrendIcon = trendIconMap[course.enrollmentTrend];
+          return (
+            <article
+              key={course.courseId}
+              className={clsx(
+                'flex h-full flex-col rounded-2xl border border-slate-200 bg-[#BDD0D2]/60 p-6 shadow-sm transition-all',
+                selectedCourseId === course.courseId
+                  ? 'ring-2 ring-offset-2 ring-[#33A1CD] ring-offset-white'
+                  : 'hover:shadow-md',
+              )}
+            >
+              <header className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium uppercase tracking-wide text-slate-600">Course</p>
+                  <h3 className="text-xl font-semibold text-slate-900">{course.courseName}</h3>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onSelectCourse(course.courseId)}
+                  className={clsx(
+                    'rounded-full px-4 py-1 text-sm font-semibold transition-colors',
+                    selectedCourseId === course.courseId
+                      ? 'bg-[#33A1CD] text-white'
+                      : 'bg-white text-slate-700 hover:bg-slate-100',
+                  )}
+                >
+                  {selectedCourseId === course.courseId ? 'Selected' : 'Select'}
+                </button>
+              </header>
+
+              <dl className="mt-6 grid grid-cols-2 gap-3 text-sm text-slate-700">
+                <div className="rounded-xl bg-white/70 p-3">
+                  <dt className="flex items-center gap-2 font-medium text-slate-600">
+                    <Users2 className="h-4 w-4" aria-hidden="true" /> Total Enrolled
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold text-slate-900">{course.totalEnrolled}</dd>
+                </div>
+                <div className="rounded-xl bg-white/70 p-3">
+                  <dt className="flex items-center gap-2 font-medium text-slate-600">
+                    <CheckCircle2 className="h-4 w-4 text-emerald-600" aria-hidden="true" /> Active
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold text-emerald-700">{course.activeStudents}</dd>
+                </div>
+                <div className="rounded-xl bg-white/70 p-3">
+                  <dt className="flex items-center gap-2 font-medium text-slate-600">
+                    <GraduationStatIcon className="h-4 w-4 text-sky-600" aria-hidden="true" /> Completed
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold text-sky-700">{course.completedStudents}</dd>
+                </div>
+                <div className="rounded-xl bg-white/70 p-3">
+                  <dt className="flex items-center gap-2 font-medium text-slate-600">
+                    <XCircle className="h-4 w-4 text-rose-600" aria-hidden="true" /> Dropped
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold text-rose-700">{course.droppedStudents}</dd>
+                </div>
+              </dl>
+
+              <div className="mt-auto flex flex-col gap-4 pt-6">
+                <div className="flex items-center justify-between rounded-xl bg-white/80 p-3">
+                  <div>
+                    <p className="text-sm font-medium text-slate-600">Enrollment Trend</p>
+                    <p className="text-sm text-slate-700">{course.enrollmentTrend}</p>
+                  </div>
+                  <TrendIcon className={clsx('h-6 w-6', trendColorMap[course.enrollmentTrend])} aria-hidden="true" />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onViewStudents(course.courseId)}
+                  className="w-full rounded-xl bg-[#DD7C5E] px-4 py-3 text-base font-semibold text-white shadow-md transition-colors hover:bg-[#c66a51] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#33A1CD] focus-visible:ring-offset-2"
+                >
+                  View Students Enrolled
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function GraduationStatIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" {...props}>
+      <path
+        d="M3 7l9-4 9 4-9 4-9-4Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M21 10v6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M3 10.5v5a2 2 0 0 0 1.05 1.75L12 21l7.95-3.75A2 2 0 0 0 21 15.5v-5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default CourseEnrollmentCards;

--- a/src/app/admin/students/components/EnrolledStudentsList.tsx
+++ b/src/app/admin/students/components/EnrolledStudentsList.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Mail, Users, FileDown, ArrowRightLeft } from 'lucide-react';
+import clsx from 'clsx';
+import StatusBadge from './StatusBadge';
+import type { Student } from '../../../../types/enrollment';
+
+interface EnrolledStudentsListProps {
+  students: Student[];
+  selectedStudentId: string | null;
+  selectedStudentIds: string[];
+  onSelectStudent: (studentId: string) => void;
+  onToggleStudentSelection: (studentId: string) => void;
+  onToggleSelectAll: () => void;
+  onBulkEmail?: (studentIds: string[]) => void;
+  onExport?: (studentIds: string[]) => void;
+  onTransfer?: (studentIds: string[]) => void;
+}
+
+export function EnrolledStudentsList({
+  students,
+  selectedStudentId,
+  selectedStudentIds,
+  onSelectStudent,
+  onToggleStudentSelection,
+  onToggleSelectAll,
+  onBulkEmail,
+  onExport,
+  onTransfer,
+}: EnrolledStudentsListProps) {
+  const allSelected = useMemo(
+    () => students.length > 0 && selectedStudentIds.length === students.length,
+    [selectedStudentIds.length, students.length],
+  );
+
+  return (
+    <section aria-label="Enrolled students" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Enrolled Students</h2>
+          <p className="text-sm text-slate-600">
+            Manage individual student records, send communications, and export course enrollment data.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onBulkEmail?.(selectedStudentIds)}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            <Mail className="h-4 w-4" aria-hidden="true" />
+            Bulk Email
+          </button>
+          <button
+            type="button"
+            onClick={() => onExport?.(selectedStudentIds)}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            <FileDown className="h-4 w-4" aria-hidden="true" />
+            Export
+          </button>
+          <button
+            type="button"
+            onClick={() => onTransfer?.(selectedStudentIds)}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            <ArrowRightLeft className="h-4 w-4" aria-hidden="true" />
+            Transfer
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-6 overflow-hidden rounded-xl border border-slate-200">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200">
+            <thead className="bg-slate-50">
+              <tr>
+                <th scope="col" className="px-4 py-3">
+                  <span className="sr-only">Select</span>
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-slate-300 text-[#33A1CD] focus:ring-[#33A1CD]"
+                    checked={allSelected}
+                    onChange={onToggleSelectAll}
+                    aria-label={allSelected ? 'Deselect all students' : 'Select all students'}
+                  />
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600">
+                  Student
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600">
+                  Status
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600">
+                  Enrollment Date
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600">
+                  Progress
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-sm font-semibold uppercase tracking-wide text-slate-600">
+                  Last Activity
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white">
+              {students.map((student) => {
+                const isSelected = selectedStudentIds.includes(student.id);
+                const isFocused = selectedStudentId === student.id;
+                const enrollmentDate = new Date(student.enrollmentDate).toLocaleDateString();
+                const lastActivity = student.lastActivity
+                  ? new Date(student.lastActivity).toLocaleDateString()
+                  : '—';
+
+                return (
+                  <tr
+                    key={student.id}
+                    className={clsx(
+                      'cursor-pointer transition-colors hover:bg-slate-50',
+                      isFocused && 'bg-sky-50/60',
+                    )}
+                    onClick={() => onSelectStudent(student.id)}
+                  >
+                    <td className="px-4 py-4">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-slate-300 text-[#33A1CD] focus:ring-[#33A1CD]"
+                        checked={isSelected}
+                        onChange={(event) => {
+                          event.stopPropagation();
+                          onToggleStudentSelection(student.id);
+                        }}
+                        aria-label={`Select ${student.fullName}`}
+                      />
+                    </td>
+                    <td className="px-4 py-4">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#BDD0D2]/70 text-base font-semibold text-slate-800">
+                          {student.fullName
+                            .split(' ')
+                            .map((name) => name.charAt(0))
+                            .join('')
+                            .slice(0, 2)
+                            .toUpperCase()}
+                        </div>
+                        <div>
+                          <p className="text-sm font-semibold text-slate-900">{student.fullName}</p>
+                          <p className="text-sm text-slate-600">{student.email}</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-4">
+                      <StatusBadge status={student.currentStatus} />
+                    </td>
+                    <td className="px-4 py-4 text-sm text-slate-700">{enrollmentDate}</td>
+                    <td className="px-4 py-4 text-sm text-slate-700">
+                      <div className="flex items-center gap-2">
+                        <div className="h-2 flex-1 rounded-full bg-slate-100">
+                          <div
+                            className="h-2 rounded-full bg-[#33A1CD]"
+                            style={{ width: `${Math.min(100, Math.max(0, student.progressPercentage ?? 0))}%` }}
+                          />
+                        </div>
+                        <span>{student.progressPercentage ?? 0}%</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-sm text-slate-700">{lastActivity}</td>
+                  </tr>
+                );
+              })}
+              {students.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-12 text-center text-sm text-slate-500">
+                    No students enrolled for this course yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col items-start gap-3 rounded-xl bg-slate-50 p-4 text-sm text-slate-600 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2 font-medium text-slate-700">
+          <Users className="h-4 w-4" aria-hidden="true" />
+          {selectedStudentIds.length} selected
+        </div>
+        <p>
+          Tip: use the bulk actions above to send updates, export reports, or transfer students between courses.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default EnrolledStudentsList;

--- a/src/app/admin/students/components/StatusBadge.tsx
+++ b/src/app/admin/students/components/StatusBadge.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx';
+import type { EnrollmentStatus } from '../../../../types/enrollment';
+
+interface StatusBadgeProps {
+  status: EnrollmentStatus;
+  className?: string;
+}
+
+const statusStyles: Record<EnrollmentStatus, string> = {
+  active: 'bg-emerald-100 text-emerald-700 ring-emerald-200',
+  completed: 'bg-sky-100 text-sky-700 ring-sky-200',
+  dropped: 'bg-rose-100 text-rose-700 ring-rose-200',
+};
+
+const statusLabels: Record<EnrollmentStatus, string> = {
+  active: 'Active',
+  completed: 'Completed',
+  dropped: 'Dropped',
+};
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium ring-1 ring-inset transition-colors',
+        statusStyles[status],
+        className,
+      )}
+    >
+      <span className="h-2 w-2 rounded-full bg-current" aria-hidden="true" />
+      {statusLabels[status]}
+    </span>
+  );
+}
+
+export default StatusBadge;

--- a/src/app/admin/students/components/StatusSelector.tsx
+++ b/src/app/admin/students/components/StatusSelector.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { CheckCircle2, GraduationCap, XCircle } from 'lucide-react';
+import clsx from 'clsx';
+import type { EnrollmentStatus } from '../../../../types/enrollment';
+
+interface StatusOption {
+  value: EnrollmentStatus;
+  label: string;
+  description: string;
+  icon: React.ElementType;
+  color: string;
+  indicator: string;
+}
+
+const STATUS_OPTIONS: StatusOption[] = [
+  {
+    value: 'active',
+    label: 'Active',
+    description: 'Student is currently progressing through the course.',
+    icon: CheckCircle2,
+    color: 'text-emerald-600',
+    indicator: 'bg-emerald-500',
+  },
+  {
+    value: 'completed',
+    label: 'Completed',
+    description: 'Course finished and certificate ready to generate.',
+    icon: GraduationCap,
+    color: 'text-sky-600',
+    indicator: 'bg-sky-500',
+  },
+  {
+    value: 'dropped',
+    label: 'Dropped',
+    description: 'Student withdrew or became inactive.',
+    icon: XCircle,
+    color: 'text-rose-600',
+    indicator: 'bg-rose-500',
+  },
+];
+
+interface StatusSelectorProps {
+  value: EnrollmentStatus;
+  onChange: (status: EnrollmentStatus) => void;
+  disabledStatuses?: EnrollmentStatus[];
+  className?: string;
+  legend?: string;
+  name?: string;
+}
+
+export function StatusSelector({
+  value,
+  onChange,
+  disabledStatuses = [],
+  className,
+  legend = 'Current Status',
+  name = 'currentStatus',
+}: StatusSelectorProps) {
+  return (
+    <fieldset className={clsx('space-y-4', className)}>
+      <legend className="text-lg font-semibold text-slate-900">{legend}</legend>
+      <div className="grid gap-3 md:grid-cols-3">
+        {STATUS_OPTIONS.map((option) => {
+          const isSelected = value === option.value;
+          const isDisabled = disabledStatuses.includes(option.value);
+
+          return (
+            <label
+              key={option.value}
+              className={clsx(
+                'flex cursor-pointer items-start gap-3 rounded-xl border border-slate-200 bg-white/80 p-4 shadow-sm transition-all focus-within:ring-2 focus-within:ring-[#33A1CD]',
+                isSelected && 'border-[#33A1CD] shadow-md',
+                isDisabled && 'cursor-not-allowed opacity-50',
+              )}
+            >
+              <input
+                type="radio"
+                name={name}
+                value={option.value}
+                checked={isSelected}
+                disabled={isDisabled}
+                onChange={() => onChange(option.value)}
+                className="sr-only"
+              />
+              <span className={clsx('mt-0.5 flex h-3 w-3 items-center justify-center rounded-full', option.indicator)}>
+                <span className="sr-only">{option.label} status</span>
+              </span>
+              <div>
+                <div className="flex items-center gap-2 text-base font-semibold text-slate-900">
+                  <option.icon className={clsx('h-5 w-5', option.color)} aria-hidden="true" />
+                  {option.label}
+                </div>
+                <p className="mt-1 text-sm text-slate-600">{option.description}</p>
+              </div>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+export default StatusSelector;

--- a/src/app/admin/students/components/StudentActions.tsx
+++ b/src/app/admin/students/components/StudentActions.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import clsx from 'clsx';
+import { RefreshCcw } from 'lucide-react';
+import type { EnrollmentStatus } from '../../../../types/enrollment';
+import StatusSelector from './StatusSelector';
+
+interface StudentActionsProps {
+  isEditing: boolean;
+  disableSave?: boolean;
+  disableDelete?: boolean;
+  onDelete: () => void;
+  onReset: () => void;
+  selectedStudentCount: number;
+  bulkStatus: EnrollmentStatus;
+  onBulkStatusChange: (status: EnrollmentStatus) => void;
+  onApplyBulkStatus: () => void;
+  isBulkActionDisabled?: boolean;
+  isSaving?: boolean;
+  isDeleting?: boolean;
+}
+
+export function StudentActions({
+  isEditing,
+  disableSave,
+  disableDelete,
+  onDelete,
+  onReset,
+  selectedStudentCount,
+  bulkStatus,
+  onBulkStatusChange,
+  onApplyBulkStatus,
+  isBulkActionDisabled,
+  isSaving,
+  isDeleting,
+}: StudentActionsProps) {
+  return (
+    <div className="mt-8 space-y-6">
+      <div className="flex flex-col gap-4 rounded-2xl bg-slate-50 p-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">Bulk Status Update</h3>
+          <p className="text-sm text-slate-600">
+            Apply a new enrollment status to the selected students. Use this to graduate active cohorts or manage drop-outs
+            efficiently.
+          </p>
+        </div>
+        <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row md:items-end">
+          <StatusSelector
+            legend="Bulk status"
+            name="bulkStatus"
+            value={bulkStatus}
+            onChange={onBulkStatusChange}
+            className="md:max-w-md"
+          />
+          <button
+            type="button"
+            onClick={onApplyBulkStatus}
+            disabled={isBulkActionDisabled || selectedStudentCount === 0}
+            className={clsx(
+              'inline-flex items-center justify-center rounded-xl bg-[#33A1CD] px-6 py-3 text-sm font-semibold text-white shadow-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#33A1CD] focus-visible:ring-offset-2',
+              (isBulkActionDisabled || selectedStudentCount === 0) && 'cursor-not-allowed opacity-60',
+            )}
+          >
+            Update {selectedStudentCount > 0 ? `${selectedStudentCount} Students` : 'Students'}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end">
+        <button
+          type="button"
+          onClick={onReset}
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-5 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+        >
+          <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+          Reset Form
+        </button>
+        <div className="flex flex-col gap-3 md:flex-row">
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={disableDelete}
+            className={clsx(
+              'rounded-xl bg-white px-6 py-3 text-sm font-semibold text-rose-600 ring-1 ring-inset ring-rose-200 transition hover:bg-rose-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400',
+              disableDelete && 'cursor-not-allowed opacity-60',
+            )}
+          >
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </button>
+          <button
+            type="submit"
+            disabled={disableSave}
+            className={clsx(
+              'rounded-xl bg-[#DD7C5E] px-6 py-3 text-base font-semibold text-white shadow-md transition hover:bg-[#c66a51] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#33A1CD] focus-visible:ring-offset-2',
+              disableSave && 'cursor-not-allowed opacity-60',
+            )}
+          >
+            {isSaving ? 'Saving…' : isEditing ? 'Save Changes' : 'Create Student'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default StudentActions;

--- a/src/app/admin/students/components/StudentForm.tsx
+++ b/src/app/admin/students/components/StudentForm.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import clsx from 'clsx';
+import { AlertCircle } from 'lucide-react';
+import type { FormEvent } from 'react';
+import type { StudentFormData, StatusHistoryEntry, EnrollmentStatus } from '../../../../types/enrollment';
+import StatusSelector from './StatusSelector';
+import StudentActions from './StudentActions';
+
+interface StudentFormProps {
+  formData: StudentFormData;
+  errors: Partial<Record<keyof StudentFormData | 'generic', string>>;
+  onChange: <Key extends keyof StudentFormData>(field: Key, value: StudentFormData[Key]) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onDelete: () => void;
+  onReset: () => void;
+  onBulkStatusChange: (status: EnrollmentStatus) => void;
+  onApplyBulkStatus: () => void;
+  bulkStatus: EnrollmentStatus;
+  selectedStudentCount: number;
+  isEditing: boolean;
+  statusHistory: StatusHistoryEntry[];
+  disabledStatuses?: EnrollmentStatus[];
+  disableSave?: boolean;
+  disableDelete?: boolean;
+  isSaving?: boolean;
+  isDeleting?: boolean;
+}
+
+export function StudentForm({
+  formData,
+  errors,
+  onChange,
+  onSubmit,
+  onDelete,
+  onReset,
+  onBulkStatusChange,
+  onApplyBulkStatus,
+  bulkStatus,
+  selectedStudentCount,
+  isEditing,
+  statusHistory,
+  disabledStatuses = [],
+  disableSave,
+  disableDelete,
+  isSaving,
+  isDeleting,
+}: StudentFormProps) {
+  return (
+    <section aria-label="Student information" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <form onSubmit={onSubmit} noValidate>
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900">Student Information</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              Update enrollment details, track progress, and manage communication preferences from a single location.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="fullName" className="text-sm font-semibold text-slate-800">
+                Full Name
+              </label>
+              <input
+                id="fullName"
+                name="fullName"
+                type="text"
+                value={formData.fullName}
+                onChange={(event) => onChange('fullName', event.target.value)}
+                className={clsx(
+                  'rounded-xl border border-slate-200 bg-[#BDD0D2]/60 px-4 py-3 text-base text-slate-900 shadow-inner focus:border-[#33A1CD] focus:outline-none focus:ring-2 focus:ring-[#33A1CD] focus:ring-offset-1',
+                  errors.fullName && 'border-rose-300 ring-rose-200',
+                )}
+                placeholder="Jane Doe"
+                required
+              />
+              {errors.fullName && (
+                <p className="flex items-center gap-1 text-sm text-rose-600">
+                  <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                  {errors.fullName}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="email" className="text-sm font-semibold text-slate-800">
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={(event) => onChange('email', event.target.value)}
+                className={clsx(
+                  'rounded-xl border border-slate-200 bg-[#BDD0D2]/60 px-4 py-3 text-base text-slate-900 shadow-inner focus:border-[#33A1CD] focus:outline-none focus:ring-2 focus:ring-[#33A1CD] focus:ring-offset-1',
+                  errors.email && 'border-rose-300 ring-rose-200',
+                )}
+                placeholder="jane.doe@email.com"
+                required
+              />
+              {errors.email && (
+                <p className="flex items-center gap-1 text-sm text-rose-600">
+                  <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                  {errors.email}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="enrollmentDate" className="text-sm font-semibold text-slate-800">
+                Enrollment Date
+              </label>
+              <input
+                id="enrollmentDate"
+                name="enrollmentDate"
+                type="date"
+                value={formData.enrollmentDate}
+                onChange={(event) => onChange('enrollmentDate', event.target.value)}
+                className={clsx(
+                  'rounded-xl border border-slate-200 bg-[#BDD0D2]/60 px-4 py-3 text-base text-slate-900 shadow-inner focus:border-[#33A1CD] focus:outline-none focus:ring-2 focus:ring-[#33A1CD] focus:ring-offset-1',
+                  errors.enrollmentDate && 'border-rose-300 ring-rose-200',
+                )}
+                required
+                max={new Date().toISOString().split('T')[0]}
+              />
+              {errors.enrollmentDate && (
+                <p className="flex items-center gap-1 text-sm text-rose-600">
+                  <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                  {errors.enrollmentDate}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="status" className="text-sm font-semibold text-slate-800">
+                Current Status
+              </label>
+              <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4">
+                <StatusSelector
+                  name="studentStatus"
+                  value={formData.currentStatus}
+                  onChange={(status) => onChange('currentStatus', status)}
+                  disabledStatuses={disabledStatuses}
+                />
+              </div>
+              {errors.currentStatus && (
+                <p className="flex items-center gap-1 text-sm text-rose-600">
+                  <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                  {errors.currentStatus}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {statusHistory.length > 0 && (
+            <div className="rounded-xl bg-slate-50 p-4">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600">Status History</h3>
+              <ol className="mt-3 space-y-2 text-sm text-slate-700">
+                {statusHistory.map((entry) => (
+                  <li key={`${entry.status}-${entry.timestamp}`} className="flex items-start gap-3 rounded-lg bg-white/70 p-3">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-[#33A1CD]" aria-hidden="true" />
+                    <div>
+                      <p className="font-semibold capitalize text-slate-900">{entry.status}</p>
+                      <p>{new Date(entry.timestamp).toLocaleString()}</p>
+                      {entry.note && <p className="text-slate-500">{entry.note}</p>}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </div>
+
+        <StudentActions
+          isEditing={isEditing}
+          disableSave={disableSave}
+          disableDelete={disableDelete}
+          onDelete={onDelete}
+          onReset={onReset}
+          selectedStudentCount={selectedStudentCount}
+          bulkStatus={bulkStatus}
+          onBulkStatusChange={onBulkStatusChange}
+          onApplyBulkStatus={onApplyBulkStatus}
+          isBulkActionDisabled={isSaving || isDeleting}
+          isSaving={isSaving}
+          isDeleting={isDeleting}
+        />
+        {errors.generic && (
+          <p className="mt-4 flex items-center gap-2 text-sm font-medium text-rose-600">
+            <AlertCircle className="h-4 w-4" aria-hidden="true" />
+            {errors.generic}
+          </p>
+        )}
+      </form>
+    </section>
+  );
+}
+
+export default StudentForm;

--- a/src/app/admin/students/page.tsx
+++ b/src/app/admin/students/page.tsx
@@ -1,0 +1,733 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import AdminSidebar from '../components/AdminSidebar';
+import CourseEnrollmentCards from './components/CourseEnrollmentCards';
+import EnrolledStudentsList from './components/EnrolledStudentsList';
+import StudentForm from './components/StudentForm';
+import ConfirmationDialog from '../components/ConfirmationDialog';
+import Toast, { type ToastTone } from '../components/Toast';
+import type {
+  CourseEnrollment,
+  EnrollmentStatus,
+  StatusHistoryEntry,
+  Student,
+  StudentFormData,
+} from '../../../types/enrollment';
+
+const formatDateInput = (value: Date | string) => {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) {
+    return new Date().toISOString().split('T')[0];
+  }
+  return date.toISOString().split('T')[0];
+};
+
+const createEmptyForm = (): StudentFormData => ({
+  fullName: '',
+  email: '',
+  enrollmentDate: new Date().toISOString().split('T')[0],
+  currentStatus: 'active',
+});
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `student-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+type FormErrors = Partial<Record<keyof StudentFormData | 'generic', string>>;
+type StatusHistoryMap = Record<string, StatusHistoryEntry[]>;
+
+type ToastState = { message: string; tone: ToastTone; actionLabel?: string; onAction?: () => void } | null;
+
+interface UndoStatusChange {
+  studentId: string;
+  previousStatus: EnrollmentStatus;
+  previousHistory: StatusHistoryEntry[];
+  previousCompletionDate?: Date;
+}
+
+interface UndoState {
+  students: UndoStatusChange[];
+  courseIds: string[];
+}
+
+const initialCourses: CourseEnrollment[] = [
+  {
+    courseId: 'course-1',
+    courseName: 'Full-Stack Web Development',
+    totalEnrolled: 3,
+    activeStudents: 2,
+    completedStudents: 1,
+    droppedStudents: 0,
+    enrollmentTrend: 'increasing',
+  },
+  {
+    courseId: 'course-2',
+    courseName: 'Data Science Foundations',
+    totalEnrolled: 2,
+    activeStudents: 1,
+    completedStudents: 0,
+    droppedStudents: 1,
+    enrollmentTrend: 'stable',
+  },
+];
+
+const initialStudents: Student[] = [
+  {
+    id: 'student-1',
+    fullName: 'Amelia West',
+    email: 'amelia.west@example.com',
+    enrollmentDate: new Date('2024-01-05T08:00:00Z'),
+    currentStatus: 'active',
+    courseId: 'course-1',
+    courseName: 'Full-Stack Web Development',
+    progressPercentage: 72,
+    lastActivity: new Date('2024-05-12T10:30:00Z'),
+    statusHistory: [
+      {
+        status: 'active',
+        timestamp: '2024-01-05T08:00:00Z',
+        note: 'Enrolled via admin dashboard',
+      },
+    ],
+  },
+  {
+    id: 'student-2',
+    fullName: 'Marcus Lopez',
+    email: 'marcus.lopez@example.com',
+    enrollmentDate: new Date('2024-02-19T09:00:00Z'),
+    currentStatus: 'active',
+    courseId: 'course-1',
+    courseName: 'Full-Stack Web Development',
+    progressPercentage: 38,
+    lastActivity: new Date('2024-05-10T14:15:00Z'),
+    statusHistory: [
+      {
+        status: 'active',
+        timestamp: '2024-02-19T09:00:00Z',
+        note: 'Transferred from cohort 2023',
+      },
+    ],
+  },
+  {
+    id: 'student-3',
+    fullName: 'Priya Natarajan',
+    email: 'priya.natarajan@example.com',
+    enrollmentDate: new Date('2023-10-01T08:00:00Z'),
+    currentStatus: 'completed',
+    courseId: 'course-1',
+    courseName: 'Full-Stack Web Development',
+    progressPercentage: 100,
+    lastActivity: new Date('2024-03-22T16:00:00Z'),
+    completionDate: new Date('2024-03-20T12:00:00Z'),
+    statusHistory: [
+      {
+        status: 'active',
+        timestamp: '2023-10-01T08:00:00Z',
+      },
+      {
+        status: 'completed',
+        timestamp: '2024-03-20T12:00:00Z',
+        note: 'Completed capstone project',
+      },
+    ],
+  },
+  {
+    id: 'student-4',
+    fullName: 'Svenja Krüger',
+    email: 'svenja.kruger@example.com',
+    enrollmentDate: new Date('2024-01-12T08:00:00Z'),
+    currentStatus: 'active',
+    courseId: 'course-2',
+    courseName: 'Data Science Foundations',
+    progressPercentage: 54,
+    lastActivity: new Date('2024-05-08T12:45:00Z'),
+    statusHistory: [
+      {
+        status: 'active',
+        timestamp: '2024-01-12T08:00:00Z',
+      },
+    ],
+  },
+  {
+    id: 'student-5',
+    fullName: 'Isaiah Woods',
+    email: 'isaiah.woods@example.com',
+    enrollmentDate: new Date('2023-11-02T08:00:00Z'),
+    currentStatus: 'dropped',
+    courseId: 'course-2',
+    courseName: 'Data Science Foundations',
+    progressPercentage: 12,
+    lastActivity: new Date('2024-01-28T09:30:00Z'),
+    dropReason: 'Changed career focus',
+    statusHistory: [
+      {
+        status: 'active',
+        timestamp: '2023-11-02T08:00:00Z',
+      },
+      {
+        status: 'dropped',
+        timestamp: '2024-02-15T10:00:00Z',
+        note: 'Withdrew after one-on-one session',
+      },
+    ],
+  },
+];
+
+const buildStatusHistoryMap = (seed: Student[]): StatusHistoryMap => {
+  return seed.reduce<StatusHistoryMap>((acc, student) => {
+    if (student.statusHistory && student.statusHistory.length > 0) {
+      acc[student.id] = student.statusHistory;
+    }
+    return acc;
+  }, {});
+};
+
+export default function StudentEnrollmentPage() {
+  const [courses, setCourses] = useState<CourseEnrollment[]>(initialCourses);
+  const [students, setStudents] = useState<Student[]>(initialStudents);
+  const [statusHistoryMap, setStatusHistoryMap] = useState<StatusHistoryMap>(() => buildStatusHistoryMap(initialStudents));
+  const [selectedCourseId, setSelectedCourseId] = useState<string>(initialCourses[0]?.courseId ?? '');
+  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null);
+  const [selectedStudentIds, setSelectedStudentIds] = useState<string[]>([]);
+  const [formData, setFormData] = useState<StudentFormData>(() => {
+    const firstForCourse = initialStudents.find((student) => student.courseId === initialCourses[0]?.courseId);
+    return firstForCourse
+      ? {
+          fullName: firstForCourse.fullName,
+          email: firstForCourse.email,
+          enrollmentDate: formatDateInput(firstForCourse.enrollmentDate),
+          currentStatus: firstForCourse.currentStatus,
+        }
+      : createEmptyForm();
+  });
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [bulkStatus, setBulkStatus] = useState<EnrollmentStatus>('active');
+  const [toast, setToast] = useState<ToastState>(null);
+  const [undoState, setUndoState] = useState<UndoState | null>(null);
+
+  const selectedCourse = useMemo(
+    () => courses.find((course) => course.courseId === selectedCourseId) ?? courses[0],
+    [courses, selectedCourseId],
+  );
+
+  const filteredStudents = useMemo(
+    () => students.filter((student) => student.courseId === selectedCourse?.courseId),
+    [students, selectedCourse?.courseId],
+  );
+
+  const selectedStudent = useMemo(
+    () => students.find((student) => student.id === selectedStudentId) ?? null,
+    [students, selectedStudentId],
+  );
+
+  const statusHistoryForStudent = selectedStudentId ? statusHistoryMap[selectedStudentId] ?? [] : [];
+
+  useEffect(() => {
+    if (!selectedCourse) {
+      return;
+    }
+
+    if (!selectedStudentId || !filteredStudents.some((student) => student.id === selectedStudentId)) {
+      setSelectedStudentId(filteredStudents[0]?.id ?? null);
+    }
+
+    setSelectedStudentIds((previous) => previous.filter((id) => filteredStudents.some((student) => student.id === id)));
+  }, [filteredStudents, selectedCourse, selectedStudentId]);
+
+  useEffect(() => {
+    if (!selectedStudent) {
+      setFormData(createEmptyForm());
+      return;
+    }
+
+    setFormData({
+      fullName: selectedStudent.fullName,
+      email: selectedStudent.email,
+      enrollmentDate: formatDateInput(selectedStudent.enrollmentDate),
+      currentStatus: selectedStudent.currentStatus,
+    });
+    setFormErrors({});
+  }, [selectedStudent]);
+
+  const validateForm = (data: StudentFormData): FormErrors => {
+    const errors: FormErrors = {};
+    if (!data.fullName.trim()) {
+      errors.fullName = 'Full name is required.';
+    }
+    if (!data.email.trim()) {
+      errors.email = 'Email address is required.';
+    } else {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(data.email)) {
+        errors.email = 'Enter a valid email address.';
+      }
+    }
+
+    const otherStudent = students.find(
+      (student) => student.email.toLowerCase() === data.email.toLowerCase() && student.id !== selectedStudentId,
+    );
+    if (otherStudent) {
+      errors.email = 'A student with this email already exists in the system.';
+    }
+
+    if (!data.enrollmentDate) {
+      errors.enrollmentDate = 'Enrollment date is required.';
+    } else {
+      const date = new Date(data.enrollmentDate);
+      const now = new Date();
+      if (Number.isNaN(date.getTime())) {
+        errors.enrollmentDate = 'Enter a valid enrollment date.';
+      } else if (date > now) {
+        errors.enrollmentDate = 'Enrollment date cannot be in the future.';
+      }
+    }
+
+    if (!data.currentStatus) {
+      errors.currentStatus = 'Select the current enrollment status.';
+    }
+
+    return errors;
+  };
+
+  const recalculateCourseMetrics = (courseId: string, updatedStudents: Student[]) => {
+    setCourses((previous) =>
+      previous.map((course) => {
+        if (course.courseId !== courseId) {
+          return course;
+        }
+        const courseStudents = updatedStudents.filter((student) => student.courseId === courseId);
+        const activeStudents = courseStudents.filter((student) => student.currentStatus === 'active').length;
+        const completedStudents = courseStudents.filter((student) => student.currentStatus === 'completed').length;
+        const droppedStudents = courseStudents.filter((student) => student.currentStatus === 'dropped').length;
+        const totalEnrolled = courseStudents.length;
+        const difference = totalEnrolled - course.totalEnrolled;
+        const enrollmentTrend =
+          difference > 0 ? 'increasing' : difference < 0 ? 'decreasing' : course.enrollmentTrend;
+
+        return {
+          ...course,
+          totalEnrolled,
+          activeStudents,
+          completedStudents,
+          droppedStudents,
+          enrollmentTrend,
+        };
+      }),
+    );
+  };
+
+  const handleSelectCourse = (courseId: string) => {
+    setSelectedCourseId(courseId);
+    setSelectedStudentId(null);
+    setSelectedStudentIds([]);
+  };
+
+  const handleFormChange = <Key extends keyof StudentFormData>(field: Key, value: StudentFormData[Key]) => {
+    if (field === 'currentStatus' && selectedStudent) {
+      const nextStatus = value as EnrollmentStatus;
+      const existingStatus = selectedStudent.currentStatus;
+      if (existingStatus !== 'active' && nextStatus !== existingStatus) {
+        setToast({
+          message: 'Only active students can transition to a different status without support approval.',
+          tone: 'error',
+        });
+        setFormErrors((previous) => ({ ...previous, generic: 'Status change not permitted for this record.' }));
+        return;
+      }
+    }
+
+    setFormData((previous) => ({ ...previous, [field]: value }));
+    setFormErrors((previous) => ({ ...previous, [field]: undefined, generic: undefined }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const errors = validateForm(formData);
+    if (Object.keys(errors).length > 0) {
+      setFormErrors(errors);
+      return;
+    }
+
+    setIsSaving(true);
+    setUndoState(null);
+
+    const nextStudents = [...students];
+    const normalizedDate = new Date(formData.enrollmentDate);
+    let nextUndoState: UndoState | null = null;
+    let toastMessage = 'Student record saved successfully.';
+    let toastTone: ToastTone = 'success';
+
+    if (selectedStudent) {
+      const index = nextStudents.findIndex((student) => student.id === selectedStudent.id);
+      if (index !== -1) {
+        const existing = nextStudents[index];
+        const statusChanged = existing.currentStatus !== formData.currentStatus;
+        let nextStatus: EnrollmentStatus = formData.currentStatus;
+        if (existing.progressPercentage && existing.progressPercentage >= 100) {
+          nextStatus = 'completed';
+        }
+
+        const previousHistory = statusHistoryMap[existing.id] ?? [];
+        const shouldRecordHistory = statusChanged || existing.currentStatus !== nextStatus;
+        const newHistoryEntry: StatusHistoryEntry | null = shouldRecordHistory
+          ? {
+              status: nextStatus,
+              timestamp: new Date().toISOString(),
+              note: statusChanged ? `Status changed from ${existing.currentStatus} to ${nextStatus}.` : undefined,
+            }
+          : null;
+        const updatedHistory = newHistoryEntry ? [...previousHistory, newHistoryEntry] : previousHistory;
+
+        const updatedStudent: Student = {
+          ...existing,
+          fullName: formData.fullName.trim(),
+          email: formData.email.trim(),
+          enrollmentDate: normalizedDate,
+          currentStatus: nextStatus,
+          completionDate: nextStatus === 'completed' ? existing.completionDate ?? new Date() : existing.completionDate,
+          statusHistory: updatedHistory,
+        };
+
+        nextStudents[index] = updatedStudent;
+
+        if (newHistoryEntry) {
+          setStatusHistoryMap((previous) => ({
+            ...previous,
+            [existing.id]: updatedHistory,
+          }));
+          nextUndoState = {
+            students: [
+              {
+                studentId: existing.id,
+                previousStatus: existing.currentStatus,
+                previousHistory,
+                previousCompletionDate: existing.completionDate,
+              },
+            ],
+            courseIds: [existing.courseId],
+          };
+          toastMessage = 'Enrollment status updated successfully.';
+        }
+
+        recalculateCourseMetrics(existing.courseId, nextStudents);
+      }
+    } else if (selectedCourse) {
+      const id = generateId();
+      const creationEntry: StatusHistoryEntry = {
+        status: formData.currentStatus,
+        timestamp: new Date().toISOString(),
+        note: 'Student record created from dashboard',
+      };
+      const newStudent: Student = {
+        id,
+        fullName: formData.fullName.trim(),
+        email: formData.email.trim(),
+        enrollmentDate: normalizedDate,
+        currentStatus: formData.currentStatus,
+        courseId: selectedCourse.courseId,
+        courseName: selectedCourse.courseName,
+        progressPercentage: 0,
+        lastActivity: new Date(),
+        statusHistory: [creationEntry],
+      };
+      nextStudents.push(newStudent);
+      setStatusHistoryMap((previous) => ({ ...previous, [id]: newStudent.statusHistory ?? [] }));
+      setSelectedStudentId(id);
+      setSelectedStudentIds([]);
+      recalculateCourseMetrics(selectedCourse.courseId, nextStudents);
+      toastMessage = 'New student added to the course.';
+    }
+
+    setStudents(nextStudents);
+    if (nextUndoState) {
+      setUndoState(nextUndoState);
+      setToast({ message: toastMessage, tone: toastTone, actionLabel: 'Undo', onAction: handleUndoStatusChange });
+    } else {
+      setToast({ message: toastMessage, tone: toastTone });
+    }
+    setIsSaving(false);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!pendingDeleteId) {
+      return;
+    }
+    const studentToRemove = students.find((student) => student.id === pendingDeleteId);
+    if (!studentToRemove) {
+      setPendingDeleteId(null);
+      return;
+    }
+    setIsDeleting(true);
+
+    const updatedStudents = students.filter((student) => student.id !== pendingDeleteId);
+    const { [pendingDeleteId]: _removed, ...nextHistory } = statusHistoryMap;
+    setStudents(updatedStudents);
+    setStatusHistoryMap(nextHistory);
+    recalculateCourseMetrics(studentToRemove.courseId, updatedStudents);
+
+    setSelectedStudentIds((previous) => previous.filter((id) => id !== pendingDeleteId));
+    setPendingDeleteId(null);
+    setSelectedStudentId((previous) => (previous === pendingDeleteId ? null : previous));
+    setFormData(createEmptyForm());
+    setUndoState(null);
+    setToast({ message: 'Student record deleted.', tone: 'info' });
+    setIsDeleting(false);
+  };
+
+  const handleDelete = () => {
+    if (!selectedStudent) {
+      setFormErrors((previous) => ({ ...previous, generic: 'Select a student record before attempting to delete.' }));
+      return;
+    }
+    setPendingDeleteId(selectedStudent.id);
+  };
+
+  const handleReset = () => {
+    setSelectedStudentId(null);
+    setFormData(createEmptyForm());
+    setFormErrors({});
+  };
+
+  const handleToggleStudentSelection = (studentId: string) => {
+    setSelectedStudentIds((previous) =>
+      previous.includes(studentId) ? previous.filter((id) => id !== studentId) : [...previous, studentId],
+    );
+  };
+
+  const handleToggleSelectAll = () => {
+    setSelectedStudentIds((previous) => {
+      if (filteredStudents.length === 0) {
+        return [];
+      }
+      if (previous.length === filteredStudents.length) {
+        return [];
+      }
+      return filteredStudents.map((student) => student.id);
+    });
+  };
+
+  const handleUndoStatusChange = () => {
+    if (!undoState) {
+      return;
+    }
+
+    const restoredStudents = students.map((student) => {
+      const undoRecord = undoState.students.find((entry) => entry.studentId === student.id);
+      if (!undoRecord) {
+        return student;
+      }
+      return {
+        ...student,
+        currentStatus: undoRecord.previousStatus,
+        statusHistory: undoRecord.previousHistory,
+        completionDate: undoRecord.previousCompletionDate,
+      };
+    });
+
+    setStudents(restoredStudents);
+    setStatusHistoryMap((previous) => {
+      const next = { ...previous };
+      undoState.students.forEach((entry) => {
+        next[entry.studentId] = entry.previousHistory;
+      });
+      return next;
+    });
+
+    undoState.courseIds.forEach((courseId) => {
+      recalculateCourseMetrics(courseId, restoredStudents);
+    });
+
+    setUndoState(null);
+    setToast({ message: 'Recent status update has been reverted.', tone: 'info' });
+  };
+
+  const handleBulkEmail = (ids: string[]) => {
+    if (ids.length === 0) {
+      setToast({ message: 'Select at least one student before sending notifications.', tone: 'error' });
+      return;
+    }
+    setToast({ message: `Email notifications queued for ${ids.length} students.`, tone: 'info' });
+  };
+
+  const handleExport = (ids: string[]) => {
+    if (ids.length === 0) {
+      setToast({ message: 'Choose students to include in the export report.', tone: 'error' });
+      return;
+    }
+    setToast({ message: `Exporting enrollment report for ${ids.length} students.`, tone: 'success' });
+  };
+
+  const handleTransfer = (ids: string[]) => {
+    if (ids.length === 0) {
+      setToast({ message: 'Select students to transfer to a different course.', tone: 'error' });
+      return;
+    }
+    setToast({ message: `Transfer workflow started for ${ids.length} students.`, tone: 'info' });
+  };
+
+  const handleApplyBulkStatus = () => {
+    if (selectedStudentIds.length === 0) {
+      setFormErrors((previous) => ({ ...previous, generic: 'Select at least one student to apply a bulk status update.' }));
+      return;
+    }
+
+    setUndoState(null);
+    const historyUpdates: Record<string, StatusHistoryEntry> = {};
+    const undoRecords: UndoStatusChange[] = [];
+    const updatedStudents = students.map((student) => {
+      if (!selectedStudentIds.includes(student.id)) {
+        return student;
+      }
+      if (student.currentStatus !== 'active' && student.currentStatus !== bulkStatus) {
+        return student;
+      }
+      if (student.currentStatus === bulkStatus) {
+        return student;
+      }
+
+      const historyEntry: StatusHistoryEntry = {
+        status: bulkStatus,
+        timestamp: new Date().toISOString(),
+        note: 'Bulk status update applied.',
+      };
+
+      historyUpdates[student.id] = historyEntry;
+
+      const previousHistory = statusHistoryMap[student.id] ?? [];
+      const nextHistory = [...previousHistory, historyEntry];
+      undoRecords.push({
+        studentId: student.id,
+        previousStatus: student.currentStatus,
+        previousHistory,
+        previousCompletionDate: student.completionDate,
+      });
+
+      return {
+        ...student,
+        currentStatus: bulkStatus,
+        completionDate: bulkStatus === 'completed' ? new Date() : student.completionDate,
+        statusHistory: nextHistory,
+      };
+    });
+
+    const affectedCourseIds = new Set(selectedStudentIds.map((id) => students.find((student) => student.id === id)?.courseId));
+    affectedCourseIds.forEach((courseId) => {
+      if (!courseId) return;
+      recalculateCourseMetrics(courseId, updatedStudents);
+    });
+
+    if (Object.keys(historyUpdates).length > 0) {
+      setStatusHistoryMap((previous) => {
+        const next = { ...previous };
+        Object.entries(historyUpdates).forEach(([id, entry]) => {
+          next[id] = [...(next[id] ?? []), entry];
+        });
+        return next;
+      });
+    }
+
+    setStudents(updatedStudents);
+    if (undoRecords.length > 0) {
+      setUndoState({
+        students: undoRecords,
+        courseIds: Array.from(affectedCourseIds).filter((value): value is string => Boolean(value)),
+      });
+      setToast({ message: 'Bulk status update complete.', tone: 'success', actionLabel: 'Undo', onAction: handleUndoStatusChange });
+    } else {
+      setToast({ message: 'No status changes were applied. Verify selected students are eligible.', tone: 'info' });
+    }
+  };
+
+  const disabledStatuses = selectedStudent && selectedStudent.currentStatus !== 'active'
+    ? (['active', 'completed', 'dropped'] as EnrollmentStatus[]).filter((status) => status !== selectedStudent.currentStatus)
+    : [];
+
+  return (
+    <div className="min-h-screen bg-[#F3F3F3]">
+      <div className="mx-auto flex max-w-[1440px] gap-6 px-4 py-10 lg:px-8">
+        <AdminSidebar className="hidden lg:flex" activePath="/admin/students" />
+        <main className="flex-1 rounded-2xl bg-[#F3F3F3] p-6 lg:bg-white/50 lg:p-10">
+          <header className="flex flex-col gap-3 border-b border-slate-200 pb-6">
+            <p className="text-sm font-semibold uppercase tracking-wide text-[#33A1CD]">Enrollment Management</p>
+            <h1 className="text-3xl font-bold text-slate-900">Student Enrollment Details</h1>
+            <p className="max-w-3xl text-sm text-slate-600">
+              Monitor course capacity, track learner progress, and maintain accurate student records with real-time validation
+              and visual enrollment insights.
+            </p>
+          </header>
+
+          <div className="mt-8 grid gap-8">
+            <CourseEnrollmentCards
+              courses={courses}
+              selectedCourseId={selectedCourse?.courseId ?? ''}
+              onSelectCourse={handleSelectCourse}
+              onViewStudents={handleSelectCourse}
+            />
+
+            <div className="grid gap-8 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+              <StudentForm
+                formData={formData}
+                errors={formErrors}
+                onChange={handleFormChange}
+                onSubmit={handleSubmit}
+                onDelete={handleDelete}
+                onReset={handleReset}
+                onBulkStatusChange={setBulkStatus}
+                onApplyBulkStatus={handleApplyBulkStatus}
+                bulkStatus={bulkStatus}
+                selectedStudentCount={selectedStudentIds.length}
+                isEditing={Boolean(selectedStudent)}
+                statusHistory={statusHistoryForStudent}
+                disabledStatuses={disabledStatuses}
+                disableSave={isSaving}
+                disableDelete={!selectedStudent || isDeleting}
+                isSaving={isSaving}
+                isDeleting={isDeleting}
+              />
+
+              <EnrolledStudentsList
+                students={filteredStudents}
+                selectedStudentId={selectedStudentId}
+                selectedStudentIds={selectedStudentIds}
+                onSelectStudent={setSelectedStudentId}
+                onToggleStudentSelection={handleToggleStudentSelection}
+                onToggleSelectAll={handleToggleSelectAll}
+                onBulkEmail={handleBulkEmail}
+                onExport={handleExport}
+                onTransfer={handleTransfer}
+              />
+            </div>
+          </div>
+        </main>
+      </div>
+
+      <ConfirmationDialog
+        open={Boolean(pendingDeleteId)}
+        title="Delete student record?"
+        description="This action will remove the student from the course enrollment list. Progress data will be retained for reporting purposes."
+        confirmLabel="Delete"
+        tone="danger"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDeleteId(null)}
+      />
+
+      {toast && (
+        <Toast
+          tone={toast.tone}
+          message={toast.message}
+          onDismiss={() => setToast(null)}
+          actionLabel={toast.actionLabel}
+          onAction={toast.onAction}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/types/enrollment.ts
+++ b/src/types/enrollment.ts
@@ -1,0 +1,42 @@
+export type EnrollmentStatus = 'active' | 'completed' | 'dropped';
+
+export type EnrollmentTrend = 'increasing' | 'stable' | 'decreasing';
+
+export interface StatusHistoryEntry {
+  status: EnrollmentStatus;
+  timestamp: string;
+  changedBy?: string;
+  note?: string;
+}
+
+export interface Student {
+  id: string;
+  fullName: string;
+  email: string;
+  enrollmentDate: Date;
+  currentStatus: EnrollmentStatus;
+  courseId: string;
+  courseName: string;
+  progressPercentage?: number;
+  lastActivity?: Date;
+  completionDate?: Date;
+  dropReason?: string;
+  statusHistory?: StatusHistoryEntry[];
+}
+
+export interface CourseEnrollment {
+  courseId: string;
+  courseName: string;
+  totalEnrolled: number;
+  activeStudents: number;
+  completedStudents: number;
+  droppedStudents: number;
+  enrollmentTrend: EnrollmentTrend;
+}
+
+export interface StudentFormData {
+  fullName: string;
+  email: string;
+  enrollmentDate: string;
+  currentStatus: EnrollmentStatus;
+}


### PR DESCRIPTION
## Summary
- add a student enrollment management page that mirrors the admin dashboard layout with sidebar navigation and analytics cards
- implement course overview, student form, bulk actions, status selector, confirmation dialog, and toast utilities for enrollment workflows
- centralize enrollment domain types for students, courses, and status history records

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06a7f5620832a8e734a5a5cf68ab5