### PR TITLE
Add secure change password Next.js page components

### DIFF
--- a/src/app/(auth)/change-password/page.tsx
+++ b/src/app/(auth)/change-password/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { AuthenticationWrapper } from '../../../components/auth/AuthenticationWrapper';
+import { ChangePasswordLayout } from '../../../components/auth/ChangePasswordLayout';
+import { PasswordForm } from '../../../components/auth/PasswordForm';
+import type { AuthenticationState, SecuritySettings } from '../../../types/security';
+
+const defaultSecuritySettings: SecuritySettings = {
+  requireCurrentPassword: true,
+  enableTwoFactor: true,
+  passwordHistoryLimit: 5,
+  sessionTimeoutMinutes: 15,
+  allowPasswordReset: true,
+  minimumLength: 12,
+  requireSymbol: true,
+  requireNumber: true,
+  requireMixedCase: true,
+};
+
+const defaultRecentPasswordHashes = [
+  '4D9F40FC9424E95A61AD77DA1215E894F2F7D3B52D6B7E1DCF5F2A9C897A5F0C',
+  '7A047F6D20513D3E5E713A9B2C73BF1C4D25265BA0F8EA7342C6A8E715731C4F',
+];
+
+const initialAuthentication: AuthenticationState = {
+  isAuthenticated: true,
+  sessionValid: true,
+  userId: 'user-1024',
+  lastPasswordChange: new Date('2024-01-10T10:00:00Z'),
+  requiresPasswordChange: false,
+};
+
+const validateSessionRemotely = async () => {
+  try {
+    const response = await fetch('/api/security/validate-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      cache: 'no-store',
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const data = (await response.json()) as { sessionValid?: boolean };
+    return Boolean(data.sessionValid);
+  } catch (error) {
+    console.warn('Unable to validate session', error);
+    return false;
+  }
+};
+
+const ChangePasswordPage = () => {
+  const [authenticationState, setAuthenticationState] = useState<AuthenticationState>(initialAuthentication);
+  const recentPasswordHashes = useMemo(() => defaultRecentPasswordHashes, []);
+
+  const handleLogout = useCallback(() => {
+    setAuthenticationState((prev) => ({ ...prev, isAuthenticated: false, sessionValid: false }));
+    if (typeof window !== 'undefined') {
+      window.location.href = '/login';
+    }
+  }, []);
+
+  const handlePasswordChanged = useCallback(() => {
+    setAuthenticationState((prev) => ({
+      ...prev,
+      lastPasswordChange: new Date(),
+      requiresPasswordChange: false,
+      sessionValid: true,
+    }));
+    setTimeout(() => {
+      setAuthenticationState((prev) => ({ ...prev, isAuthenticated: false, sessionValid: false }));
+    }, 2500);
+  }, []);
+
+  const handleSessionInvalid = useCallback(() => {
+    setAuthenticationState((prev) => ({ ...prev, sessionValid: false }));
+  }, []);
+
+  const refreshSession = useCallback(async () => {
+    const sessionValid = await validateSessionRemotely();
+    setAuthenticationState((prev) => ({ ...prev, sessionValid }));
+    return sessionValid;
+  }, []);
+
+  const securitySettings = useMemo(() => defaultSecuritySettings, []);
+
+  return (
+    <AuthenticationWrapper
+      authenticationState={authenticationState}
+      securitySettings={securitySettings}
+      onLogout={handleLogout}
+      onRefreshSession={refreshSession}
+    >
+      <ChangePasswordLayout>
+        <PasswordForm
+          securitySettings={securitySettings}
+          authenticationState={authenticationState}
+          recentPasswordHashes={recentPasswordHashes}
+          onPasswordChanged={handlePasswordChanged}
+          onSessionInvalid={handleSessionInvalid}
+          onLogout={handleLogout}
+        />
+      </ChangePasswordLayout>
+    </AuthenticationWrapper>
+  );
+};
+
+export default ChangePasswordPage;

--- a/src/components/auth/AuthenticationWrapper.tsx
+++ b/src/components/auth/AuthenticationWrapper.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import type { AuthenticationState, SecuritySettings } from '../../types/security';
+import { SecurityAlert } from './SecurityAlert';
+
+interface AuthenticationWrapperProps {
+  authenticationState: AuthenticationState;
+  securitySettings: SecuritySettings;
+  onLogout?: () => void;
+  onRefreshSession?: () => Promise<boolean>;
+  children: ReactNode;
+}
+
+export const AuthenticationWrapper = ({
+  authenticationState,
+  securitySettings,
+  onLogout,
+  onRefreshSession,
+  children,
+}: AuthenticationWrapperProps) => {
+  const [sessionValid, setSessionValid] = useState(authenticationState.sessionValid);
+  const [requiresPasswordChange, setRequiresPasswordChange] = useState(
+    authenticationState.requiresPasswordChange,
+  );
+  const [sessionCheckedAt, setSessionCheckedAt] = useState<Date>(new Date());
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setSessionValid(authenticationState.sessionValid);
+    setRequiresPasswordChange(authenticationState.requiresPasswordChange);
+  }, [authenticationState]);
+
+  useEffect(() => {
+    if (!securitySettings.sessionTimeoutMinutes) {
+      return;
+    }
+    const timeoutMs = securitySettings.sessionTimeoutMinutes * 60 * 1000;
+    const timer = setTimeout(async () => {
+      if (onRefreshSession) {
+        setLoading(true);
+        const refreshed = await onRefreshSession();
+        setLoading(false);
+        setSessionCheckedAt(new Date());
+        setSessionValid(refreshed);
+        if (!refreshed) {
+          onLogout?.();
+        }
+      } else {
+        setSessionValid(false);
+        onLogout?.();
+      }
+    }, timeoutMs);
+
+    return () => clearTimeout(timer);
+  }, [onLogout, onRefreshSession, securitySettings.sessionTimeoutMinutes, sessionCheckedAt]);
+
+  if (!authenticationState.isAuthenticated || !sessionValid) {
+    return (
+      <div className="space-y-4 p-8">
+        <SecurityAlert
+          variant="warning"
+          title="Session expired"
+          description="For security reasons you have been signed out. Please sign in again to change your password."
+          action={
+            <button
+              type="button"
+              onClick={onLogout}
+              className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            >
+              Return to login
+            </button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {requiresPasswordChange && (
+        <div className="p-6">
+          <SecurityAlert
+            variant="warning"
+            title="Password change required"
+            description="Your organization requires you to update your password before continuing."
+          />
+        </div>
+      )}
+      {loading && (
+        <div className="p-6">
+          <SecurityAlert
+            variant="info"
+            title="Refreshing session"
+            description="Confirming your session is still valid…"
+          />
+        </div>
+      )}
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+};

--- a/src/components/auth/ChangePasswordLayout.tsx
+++ b/src/components/auth/ChangePasswordLayout.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface ChangePasswordLayoutProps {
+  headline?: string;
+  subheadline?: string;
+  helpHref?: string;
+  helpLabel?: string;
+  children: ReactNode;
+  illustrationUrl?: string;
+}
+
+export const ChangePasswordLayout = ({
+  headline = 'Change Password',
+  subheadline = 'Keep your account secure by creating a strong, unique password.',
+  helpHref = '#support',
+  helpLabel = 'Help',
+  children,
+  illustrationUrl,
+}: ChangePasswordLayoutProps) => (
+  <main className="relative flex min-h-screen bg-white text-slate-900">
+    <div className="relative hidden flex-1 items-center justify-center overflow-hidden rounded-r-[2.5rem] bg-sky-500/95 p-12 text-white lg:flex">
+      <div className="absolute inset-0 bg-gradient-to-br from-sky-500 via-sky-600 to-sky-700" aria-hidden="true" />
+      <div className="relative z-10 flex h-full w-full max-w-xl flex-col justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/10 shadow-lg backdrop-blur">
+            <span className="text-xl font-semibold tracking-wide">Infoverse</span>
+          </div>
+          <div>
+            <p className="text-sm uppercase tracking-[0.2em] text-white/70">Security Center</p>
+            <h1 className="text-3xl font-semibold">Stronger passwords, safer teams.</h1>
+          </div>
+        </div>
+        <div className="relative flex flex-1 items-center justify-center">
+          {illustrationUrl ? (
+            <img
+              src={illustrationUrl}
+              alt="Information security illustration"
+              className="max-h-[420px] w-full max-w-md rounded-3xl object-cover shadow-2xl shadow-sky-900/40"
+            />
+          ) : (
+            <div className="flex h-64 w-full max-w-md items-center justify-center rounded-3xl border border-white/20 bg-white/10 text-lg font-medium text-white/80 backdrop-blur">
+              Secure Passwords
+            </div>
+          )}
+        </div>
+        <div className="space-y-1 text-white/80">
+          <p className="text-sm font-medium uppercase tracking-[0.2em]">Security tips</p>
+          <ul className="space-y-1 text-sm">
+            <li>• Use a password manager to store and generate strong passwords.</li>
+            <li>• Enable multi-factor authentication on all sensitive accounts.</li>
+            <li>• Never reuse passwords across different services.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div className="relative flex w-full flex-col justify-between px-6 py-10 sm:px-10 lg:w-[640px] lg:px-14">
+      <header className="space-y-2">
+        <p className="text-sm font-medium uppercase tracking-[0.4em] text-sky-600">Account Security</p>
+        <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">{headline}</h2>
+        <p className="text-base text-slate-600">{subheadline}</p>
+      </header>
+      <div className="mt-8 flex-1">{children}</div>
+      <footer className="mt-12 flex items-center justify-between text-sm text-slate-500">
+        <p>Need help securing your account?</p>
+        <a
+          href={helpHref}
+          className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 font-semibold text-slate-600 transition hover:border-sky-400 hover:text-sky-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500"
+        >
+          <span className="h-2 w-2 rounded-full bg-sky-500" aria-hidden="true" />
+          {helpLabel}
+        </a>
+      </footer>
+    </div>
+  </main>
+);

--- a/src/components/auth/PasswordForm.tsx
+++ b/src/components/auth/PasswordForm.tsx
@@ -1,0 +1,385 @@
+'use client';
+
+import { ChangeEvent, FormEvent, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { ShieldCheck, ShieldQuestion } from 'lucide-react';
+import type {
+  AuthenticationState,
+  PasswordChangeRequest,
+  SecuritySettings,
+} from '../../types/security';
+import { usePasswordValidation } from '../../hooks/usePasswordValidation';
+import { usePasswordSecurity } from '../../hooks/usePasswordSecurity';
+import { PasswordStrengthIndicator } from './PasswordStrengthIndicator';
+import { PasswordVisibilityToggle } from './PasswordVisibilityToggle';
+import { SecurityAlert } from './SecurityAlert';
+
+interface PasswordFormProps {
+  securitySettings: SecuritySettings;
+  authenticationState: AuthenticationState;
+  recentPasswordHashes?: string[];
+  onPasswordChanged?: () => void;
+  onSessionInvalid?: () => void;
+  onLogout?: () => void;
+}
+
+const generateStrongPassword = (length = 16) => {
+  const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^&*()-_=+[]{}';
+  const values = new Uint32Array(length);
+  if (typeof window !== 'undefined' && window.crypto?.getRandomValues) {
+    window.crypto.getRandomValues(values);
+  } else {
+    for (let i = 0; i < values.length; i += 1) {
+      values[i] = Math.floor(Math.random() * charset.length);
+    }
+  }
+  return Array.from(values)
+    .map((value) => charset[value % charset.length])
+    .join('');
+};
+
+export const PasswordForm = ({
+  securitySettings,
+  authenticationState,
+  recentPasswordHashes,
+  onPasswordChanged,
+  onSessionInvalid,
+  onLogout,
+}: PasswordFormProps) => {
+  const [form, setForm] = useState<PasswordChangeRequest>({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  const [twoFactorCode, setTwoFactorCode] = useState('');
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [statusVariant, setStatusVariant] = useState<'success' | 'error' | 'info'>('info');
+
+  const {
+    validation,
+    compromised,
+    checkingCompromise,
+    reusedPassword,
+    setIsCompromised,
+  } = usePasswordValidation(form.newPassword, {
+    securitySettings,
+    recentPasswordHashes,
+  });
+
+  const {
+    submitChange,
+    sendTwoFactorChallenge,
+    securityError,
+    isSubmitting,
+    verifyingTwoFactor,
+    rateLimited,
+    twoFactorSent,
+    setSecurityError,
+  } = usePasswordSecurity({
+    userId: authenticationState.userId,
+    securitySettings,
+    authenticationState,
+    onPasswordChanged: () => {
+      onPasswordChanged?.();
+      setStatusVariant('success');
+      setStatusMessage('Password updated successfully. You will be signed out in a moment.');
+    },
+    onSessionInvalid,
+  });
+
+  const passwordsMatch = form.newPassword.length > 0 && form.newPassword === form.confirmPassword;
+  const charCount = form.newPassword.length;
+  const formDisabled = isSubmitting || verifyingTwoFactor;
+
+  const handleInputChange = (field: keyof PasswordChangeRequest) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setForm((prev) => ({ ...prev, [field]: value }));
+      if (field === 'newPassword') {
+        setStatusMessage(null);
+        setSecurityError(null);
+      }
+    };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatusMessage(null);
+
+    if (!validation.isValid) {
+      setStatusVariant('error');
+      setStatusMessage('Please meet all password requirements before continuing.');
+      return;
+    }
+
+    if (compromised) {
+      setStatusVariant('error');
+      setStatusMessage('This password appears in known breaches. Please choose another password.');
+      return;
+    }
+
+    if (!passwordsMatch) {
+      setStatusVariant('error');
+      setStatusMessage('New password and confirmation do not match.');
+      return;
+    }
+
+    if (securitySettings.enableTwoFactor && !twoFactorCode) {
+      setStatusVariant('error');
+      setStatusMessage('Enter the verification code sent to your trusted device.');
+      return;
+    }
+
+    const result = await submitChange({
+      ...form,
+      twoFactorCode,
+    });
+
+    if (!result.success) {
+      setStatusVariant('error');
+      setStatusMessage(result.message || 'Unable to update password.');
+      return;
+    }
+
+    setStatusVariant('success');
+    setStatusMessage('Password updated successfully. For security, you will be asked to sign in again.');
+    setForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+    setTwoFactorCode('');
+    setIsCompromised(false);
+  };
+
+  const handleGeneratePassword = () => {
+    const generated = generateStrongPassword();
+    setForm((prev) => ({ ...prev, newPassword: generated, confirmPassword: generated }));
+    setStatusVariant('info');
+    setStatusMessage('Generated a strong password. Remember to store it securely.');
+  };
+
+  const breachStatus = useMemo(() => {
+    if (checkingCompromise) {
+      return 'Checking for known breaches…';
+    }
+    if (compromised) {
+      return 'Password found in breach data';
+    }
+    return 'No known breaches detected';
+  }, [checkingCompromise, compromised]);
+
+  return (
+    <form className="flex h-full flex-col gap-8" onSubmit={handleSubmit} aria-describedby="password-policy">
+      <div className="space-y-4">
+        {statusMessage && (
+          <SecurityAlert
+            variant={statusVariant === 'success' ? 'success' : statusVariant === 'error' ? 'error' : 'info'}
+            title={statusVariant === 'success' ? 'Success' : statusVariant === 'error' ? 'Action required' : 'Notice'}
+            description={statusMessage}
+          />
+        )}
+        {securityError && (
+          <SecurityAlert
+            variant="error"
+            title="Security warning"
+            description={securityError}
+            action={
+              rateLimited ? (
+                <p className="text-sm font-medium">
+                  Too many attempts. Try again later or contact support if this was not you.
+                </p>
+              ) : undefined
+            }
+          />
+        )}
+        {reusedPassword && (
+          <SecurityAlert
+            variant="warning"
+            title="Recently used password detected"
+            description="For your protection, choose a password you have not used recently."
+          />
+        )}
+        {compromised && !checkingCompromise && (
+          <SecurityAlert
+            variant="error"
+            title="Compromised password"
+            description="This password has been exposed in public data breaches. We strongly recommend choosing another password."
+            action={
+              <button
+                type="button"
+                className="rounded-full bg-white/10 px-4 py-2 text-sm font-semibold text-red-900 transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                onClick={() => setIsCompromised(false)}
+              >
+                I will choose a different password
+              </button>
+            }
+          />
+        )}
+      </div>
+
+      <div className="space-y-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-xl font-semibold text-slate-900">Secure your account</h3>
+            <p className="text-sm text-slate-500">
+              Update your password regularly and avoid reusing passwords across accounts. Changes take effect immediately.
+            </p>
+          </div>
+          <ShieldCheck className="h-8 w-8 text-sky-500" aria-hidden="true" />
+        </div>
+
+        {securitySettings.requireCurrentPassword && (
+          <div className="space-y-2">
+            <label htmlFor="currentPassword" className="text-sm font-semibold text-slate-700">
+              Current password
+            </label>
+            <div className="relative flex items-center">
+              <input
+                id="currentPassword"
+                name="currentPassword"
+                type={showCurrent ? 'text' : 'password'}
+                required={securitySettings.requireCurrentPassword}
+                value={form.currentPassword}
+                onChange={handleInputChange('currentPassword')}
+                className="h-12 w-full rounded-2xl border border-slate-200 bg-white px-4 pr-12 text-base text-slate-900 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100"
+                autoComplete="current-password"
+              />
+              <div className="absolute inset-y-0 right-3 flex items-center">
+                <PasswordVisibilityToggle visible={showCurrent} onClick={() => setShowCurrent((prev) => !prev)} />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <label htmlFor="newPassword" className="text-sm font-semibold text-slate-700">
+            New password
+          </label>
+          <div className="relative flex items-center">
+            <input
+              id="newPassword"
+              name="newPassword"
+              type={showNew ? 'text' : 'password'}
+              value={form.newPassword}
+              onChange={handleInputChange('newPassword')}
+              className={clsx(
+                'h-12 w-full rounded-2xl border bg-white px-4 pr-12 text-base shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-100',
+                validation.isValid ? 'border-emerald-300 focus:border-emerald-400' : 'border-slate-200 focus:border-sky-400',
+              )}
+              aria-describedby="password-policy"
+              autoComplete="new-password"
+            />
+            <div className="absolute inset-y-0 right-3 flex items-center gap-2">
+              <span className="text-xs font-medium text-slate-400">{charCount} chars</span>
+              <PasswordVisibilityToggle visible={showNew} onClick={() => setShowNew((prev) => !prev)} />
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="confirmPassword" className="text-sm font-semibold text-slate-700">
+            Confirm new password
+          </label>
+          <div className="relative flex items-center">
+            <input
+              id="confirmPassword"
+              name="confirmPassword"
+              type={showConfirm ? 'text' : 'password'}
+              value={form.confirmPassword}
+              onChange={handleInputChange('confirmPassword')}
+              className={clsx(
+                'h-12 w-full rounded-2xl border bg-white px-4 pr-12 text-base shadow-sm transition focus:outline-none focus:ring-2 focus:ring-sky-100',
+                passwordsMatch && form.confirmPassword
+                  ? 'border-emerald-300 focus:border-emerald-400'
+                  : 'border-slate-200 focus:border-sky-400',
+              )}
+              autoComplete="new-password"
+            />
+            <div className="absolute inset-y-0 right-3 flex items-center">
+              <PasswordVisibilityToggle visible={showConfirm} onClick={() => setShowConfirm((prev) => !prev)} />
+            </div>
+          </div>
+          <p className={clsx('text-sm', passwordsMatch ? 'text-emerald-600' : 'text-slate-500')}>
+            {passwordsMatch && form.confirmPassword ? 'Passwords match.' : 'Re-enter the new password to confirm.'}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 rounded-2xl bg-slate-50 p-4 text-sm text-slate-600">
+          <ShieldQuestion className="h-5 w-5 text-slate-400" aria-hidden="true" />
+          <div className="flex-1">
+            <p id="password-policy" className="font-medium text-slate-700">
+              Password policy
+            </p>
+            <p>
+              Minimum length {securitySettings.minimumLength}+ characters with uppercase, lowercase, numbers, and symbols. Avoid common
+              phrases or reused passwords.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded-full border border-sky-400 px-4 py-2 text-sm font-semibold text-sky-600 transition hover:bg-sky-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500"
+            onClick={handleGeneratePassword}
+          >
+            Generate secure password
+          </button>
+        </div>
+
+        {securitySettings.enableTwoFactor && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label htmlFor="twoFactorCode" className="text-sm font-semibold text-slate-700">
+                Two-factor verification code
+              </label>
+              <button
+                type="button"
+                className="text-sm font-semibold text-sky-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500"
+                onClick={sendTwoFactorChallenge}
+                disabled={verifyingTwoFactor}
+              >
+                {twoFactorSent ? 'Resend code' : 'Send code'}
+              </button>
+            </div>
+            <input
+              id="twoFactorCode"
+              name="twoFactorCode"
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              autoComplete="one-time-code"
+              value={twoFactorCode}
+              onChange={(event) => setTwoFactorCode(event.target.value)}
+              className="h-12 w-full rounded-2xl border border-slate-200 bg-white px-4 text-base text-slate-900 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100"
+              placeholder="Enter 6-digit code"
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-6 rounded-3xl bg-slate-50/80 p-4">
+          <div className="flex items-center justify-between text-sm text-slate-600">
+            <span>Breach monitoring</span>
+            <span className={clsx('font-semibold', compromised ? 'text-red-600' : 'text-emerald-600')}>
+              {breachStatus}
+            </span>
+          </div>
+          <PasswordStrengthIndicator validation={validation} isLoading={checkingCompromise} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="button"
+          onClick={onLogout}
+          className="order-2 text-sm font-semibold text-slate-500 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-400 sm:order-1"
+        >
+          Cancel and return to login
+        </button>
+        <button
+          type="submit"
+          disabled={formDisabled}
+          className="order-1 inline-flex items-center justify-center rounded-full bg-[#DD7C5E] px-6 py-3 text-base font-semibold text-white shadow-lg shadow-slate-900/10 transition hover:bg-[#c96d52] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#DD7C5E] disabled:cursor-not-allowed disabled:bg-slate-300 sm:order-2"
+        >
+          {formDisabled ? 'Securing…' : 'Change password and log out'}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/src/components/auth/PasswordStrengthIndicator.tsx
+++ b/src/components/auth/PasswordStrengthIndicator.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { CheckCircle2, Info } from 'lucide-react';
+import clsx from 'clsx';
+import type { PasswordValidation } from '../../types/security';
+import { strengthColorMap, strengthCopyMap } from '../../utils/passwordStrength';
+
+interface PasswordStrengthIndicatorProps {
+  validation: PasswordValidation;
+  isLoading?: boolean;
+}
+
+const requirementCopy: Record<keyof PasswordValidation['requirements'], string> = {
+  minLength: 'Use at least the minimum required characters.',
+  hasUppercase: 'Include uppercase letters (A-Z).',
+  hasLowercase: 'Include lowercase letters (a-z).',
+  hasNumbers: 'Include at least one number.',
+  hasSymbols: 'Include a special character.',
+  isNotCommon: 'Avoid common or predictable passwords.',
+  isNotPwned: 'Password has not appeared in known breaches.',
+  matchesHistoryPolicy: 'Do not reuse a recent password.',
+};
+
+export const PasswordStrengthIndicator = ({ validation, isLoading = false }: PasswordStrengthIndicatorProps) => {
+  const { strength, score, requirements } = validation;
+
+  return (
+    <div className="space-y-4" aria-live="polite">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-sm font-medium text-slate-700">
+          <span>Password strength</span>
+          <span>{score}%</span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200" role="progressbar" aria-valuenow={score} aria-valuemin={0} aria-valuemax={100}>
+          <div
+            className={clsx('h-full transition-all duration-300 ease-out', strengthColorMap[strength])}
+            style={{ width: `${Math.min(100, Math.max(0, score))}%` }}
+          />
+        </div>
+        <p className="text-sm text-slate-600" aria-live="assertive">
+          {isLoading ? 'Evaluating password security…' : strengthCopyMap[strength]}
+        </p>
+      </div>
+      <div className="grid gap-2 rounded-2xl bg-slate-50 p-4 text-sm text-slate-700" role="list">
+        {Object.entries(requirements).map(([key, met]) => (
+          <div
+            key={key}
+            className={clsx('flex items-start gap-2 rounded-xl border border-transparent px-3 py-2 transition', {
+              'border-emerald-200 bg-white shadow-sm': met,
+            })}
+            role="listitem"
+          >
+            <CheckCircle2
+              className={clsx('mt-0.5 h-4 w-4 flex-shrink-0', met ? 'text-emerald-500' : 'text-slate-300')}
+              aria-hidden="true"
+            />
+            <span className={clsx('leading-5', { 'text-slate-400 line-through': met })}>{requirementCopy[key as keyof PasswordValidation['requirements']]}</span>
+          </div>
+        ))}
+      </div>
+      {validation.suggestions.length > 0 && (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="flex items-start gap-2">
+            <Info className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <div className="space-y-1">
+              <p className="font-medium">Suggestions to strengthen your password</p>
+              <ul className="list-disc space-y-1 pl-5">
+                {validation.suggestions.map((suggestion) => (
+                  <li key={suggestion}>{suggestion}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/auth/PasswordVisibilityToggle.tsx
+++ b/src/components/auth/PasswordVisibilityToggle.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Eye, EyeOff } from 'lucide-react';
+import { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+interface PasswordVisibilityToggleProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  visible: boolean;
+  label?: string;
+}
+
+export const PasswordVisibilityToggle = ({
+  visible,
+  label = 'Toggle password visibility',
+  className,
+  ...props
+}: PasswordVisibilityToggleProps) => (
+  <button
+    type="button"
+    {...props}
+    className={clsx(
+      'flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500',
+      className,
+    )}
+    aria-pressed={visible}
+    aria-label={label}
+  >
+    {visible ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
+  </button>
+);

--- a/src/components/auth/SecurityAlert.tsx
+++ b/src/components/auth/SecurityAlert.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { AlertTriangle, CheckCircle2, Info, ShieldAlert } from 'lucide-react';
+import clsx from 'clsx';
+import type { JSX, ReactNode } from 'react';
+import type { SecurityAlertVariant } from '../../types/security';
+
+interface SecurityAlertProps {
+  variant?: SecurityAlertVariant;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  onDismiss?: () => void;
+}
+
+const variantStyles: Record<SecurityAlertVariant, string> = {
+  info: 'border-sky-200 bg-sky-50 text-sky-900',
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+  warning: 'border-amber-200 bg-amber-50 text-amber-900',
+  error: 'border-red-200 bg-red-50 text-red-900',
+};
+
+const variantIcons: Record<SecurityAlertVariant, JSX.Element> = {
+  info: <Info className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />, 
+  success: <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />, 
+  warning: <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />, 
+  error: <ShieldAlert className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />, 
+};
+
+export const SecurityAlert = ({
+  variant = 'info',
+  title,
+  description,
+  action,
+  onDismiss,
+}: SecurityAlertProps) => (
+  <div className={clsx('flex items-start gap-3 rounded-2xl border p-4 shadow-sm', variantStyles[variant])} role="status">
+    {variantIcons[variant]}
+    <div className="flex-1 space-y-1 text-sm">
+      <p className="font-semibold">{title}</p>
+      {description && <p className="text-sm opacity-90">{description}</p>}
+      {action && <div className="pt-2 text-sm">{action}</div>}
+    </div>
+    {onDismiss && (
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="rounded-full p-2 text-xs font-medium uppercase tracking-wide text-current transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      >
+        Dismiss
+      </button>
+    )}
+  </div>
+);

--- a/src/hooks/usePasswordSecurity.ts
+++ b/src/hooks/usePasswordSecurity.ts
@@ -1,0 +1,264 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type {
+  AuthenticationState,
+  PasswordChangeRequest,
+  PasswordSecurityTelemetry,
+  SecuritySettings,
+} from '../types/security';
+
+interface UsePasswordSecurityOptions {
+  userId: string;
+  securitySettings: SecuritySettings;
+  authenticationState: AuthenticationState;
+  onPasswordChanged?: () => void;
+  onSessionInvalid?: () => void;
+}
+
+interface PasswordChangeResponse {
+  success: boolean;
+  message?: string;
+  requiresTwoFactor?: boolean;
+}
+
+const RATE_LIMIT_MAX_ATTEMPTS = 5;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+const withinWindow = (start: Date) => Date.now() - start.getTime() < RATE_LIMIT_WINDOW_MS;
+
+export const usePasswordSecurity = ({
+  userId,
+  securitySettings,
+  authenticationState,
+  onPasswordChanged,
+  onSessionInvalid,
+}: UsePasswordSecurityOptions) => {
+  const [telemetry, setTelemetry] = useState<PasswordSecurityTelemetry>({ attempts: 0 });
+  const [securityError, setSecurityError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [verifyingTwoFactor, setVerifyingTwoFactor] = useState(false);
+  const [rateLimited, setRateLimited] = useState(false);
+  const [twoFactorSent, setTwoFactorSent] = useState(false);
+  const requestController = useRef<AbortController | null>(null);
+
+  const resetRateLimit = useCallback(() => {
+    setTelemetry({ attempts: 0 });
+    setRateLimited(false);
+  }, []);
+
+  const incrementAttempts = useCallback(() => {
+    setTelemetry((current) => {
+      const lastAttemptAt = current.lastAttemptAt && withinWindow(current.lastAttemptAt)
+        ? current.lastAttemptAt
+        : new Date();
+      const attempts =
+        current.lastAttemptAt && withinWindow(current.lastAttemptAt) ? current.attempts + 1 : 1;
+      const lockoutExpiresAt =
+        attempts >= RATE_LIMIT_MAX_ATTEMPTS
+          ? new Date(Date.now() + RATE_LIMIT_WINDOW_MS)
+          : undefined;
+      return {
+        attempts,
+        lastAttemptAt,
+        lockoutExpiresAt,
+      };
+    });
+  }, []);
+
+  const enforceRateLimit = useCallback(() => {
+    const { attempts, lastAttemptAt, lockoutExpiresAt } = telemetry;
+    if (attempts >= RATE_LIMIT_MAX_ATTEMPTS && lastAttemptAt && withinWindow(lastAttemptAt)) {
+      setRateLimited(true);
+      if (lockoutExpiresAt && lockoutExpiresAt.getTime() < Date.now()) {
+        resetRateLimit();
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }, [resetRateLimit, telemetry]);
+
+  const ensureSession = useCallback(() => {
+    if (!authenticationState.isAuthenticated || !authenticationState.sessionValid) {
+      setSecurityError('Your session has expired. Please re-authenticate to continue.');
+      onSessionInvalid?.();
+      return false;
+    }
+    return true;
+  }, [authenticationState, onSessionInvalid]);
+
+  const sendTwoFactorChallenge = useCallback(async () => {
+    if (!securitySettings.enableTwoFactor) {
+      return { success: false, message: 'Two-factor authentication is not enabled.' };
+    }
+    if (!ensureSession()) {
+      return { success: false, message: 'Session invalid.' };
+    }
+    setVerifyingTwoFactor(true);
+    try {
+      const response = await fetch('/api/security/send-2fa', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.message || 'Unable to send verification code.');
+      }
+      setTwoFactorSent(true);
+      return { success: true, message: 'Verification code sent.' };
+    } catch (error) {
+      setSecurityError((error as Error).message);
+      return { success: false, message: (error as Error).message };
+    } finally {
+      setVerifyingTwoFactor(false);
+    }
+  }, [ensureSession, securitySettings.enableTwoFactor, userId]);
+
+  const verifyTwoFactor = useCallback(
+    async (code: string) => {
+      if (!securitySettings.enableTwoFactor) {
+        return { success: true };
+      }
+      if (!ensureSession()) {
+        return { success: false, message: 'Session invalid.' };
+      }
+      setVerifyingTwoFactor(true);
+      try {
+        const response = await fetch('/api/security/verify-2fa', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId, code }),
+        });
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.message || 'Invalid verification code.');
+        }
+        return { success: true };
+      } catch (error) {
+        const message = (error as Error).message;
+        setSecurityError(message);
+        return { success: false, message };
+      } finally {
+        setVerifyingTwoFactor(false);
+      }
+    },
+    [ensureSession, securitySettings.enableTwoFactor, userId],
+  );
+
+  const submitChange = useCallback(
+    async (payload: PasswordChangeRequest): Promise<PasswordChangeResponse> => {
+      if (!ensureSession()) {
+        return { success: false, message: 'Session invalid.' };
+      }
+      if (enforceRateLimit()) {
+        return { success: false, message: 'Too many attempts. Please try again later.' };
+      }
+      if (securitySettings.requireCurrentPassword && !payload.currentPassword) {
+        return { success: false, message: 'Current password is required.' };
+      }
+      if (payload.newPassword !== payload.confirmPassword) {
+        return { success: false, message: 'Passwords do not match.' };
+      }
+      if (securitySettings.enableTwoFactor && !payload.twoFactorCode) {
+        return { success: false, message: 'Two-factor verification is required.' };
+      }
+
+      setIsSubmitting(true);
+      setSecurityError(null);
+      requestController.current?.abort();
+      requestController.current = new AbortController();
+
+      try {
+        const response = await fetch('/api/security/change-password', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          signal: requestController.current.signal,
+          body: JSON.stringify({ ...payload, userId }),
+        });
+
+        if (response.status === 429) {
+          incrementAttempts();
+          setRateLimited(true);
+          return {
+            success: false,
+            message: 'Too many attempts. Please try again after a short delay.',
+          };
+        }
+
+        if (response.status === 401) {
+          onSessionInvalid?.();
+          setSecurityError('Your session has expired. Please log in again.');
+          return {
+            success: false,
+            message: 'Session expired.',
+          };
+        }
+
+        if (response.status === 412) {
+          setSecurityError('Password policy requirements were not met.');
+          return { success: false, message: 'Password policy validation failed.' };
+        }
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.message || 'Unable to update password.');
+        }
+
+        resetRateLimit();
+        onPasswordChanged?.();
+        return { success: true };
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+          return { success: false, message: 'Request cancelled.' };
+        }
+        incrementAttempts();
+        const message = (error as Error).message || 'Unable to update password.';
+        setSecurityError(message);
+        return { success: false, message };
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [
+      ensureSession,
+      enforceRateLimit,
+      incrementAttempts,
+      onPasswordChanged,
+      onSessionInvalid,
+      resetRateLimit,
+      securitySettings.enableTwoFactor,
+      securitySettings.requireCurrentPassword,
+      userId,
+    ],
+  );
+
+  const cancelRequest = useCallback(() => {
+    requestController.current?.abort();
+  }, []);
+
+  const state = useMemo(
+    () => ({
+      telemetry,
+      securityError,
+      isSubmitting,
+      verifyingTwoFactor,
+      rateLimited,
+      twoFactorSent,
+    }),
+    [telemetry, securityError, isSubmitting, verifyingTwoFactor, rateLimited, twoFactorSent],
+  );
+
+  return {
+    ...state,
+    submitChange,
+    verifyTwoFactor,
+    sendTwoFactorChallenge,
+    cancelRequest,
+    resetRateLimit,
+    setSecurityError,
+  };
+};

--- a/src/hooks/usePasswordValidation.ts
+++ b/src/hooks/usePasswordValidation.ts
@@ -1,0 +1,187 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  PasswordValidation,
+  SecuritySettings,
+} from '../types/security';
+import { validatePassword } from '../utils/passwordValidation';
+
+export interface UsePasswordValidationOptions {
+  securitySettings: SecuritySettings;
+  recentPasswordHashes?: string[];
+  enableBreachCheck?: boolean;
+}
+
+export interface UsePasswordValidationResult {
+  validation: PasswordValidation;
+  compromised: boolean;
+  checkingCompromise: boolean;
+  reusedPassword: boolean;
+  setIsCompromised: (value: boolean) => void;
+}
+
+const toHex = (buffer: ArrayBuffer) =>
+  Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase();
+
+const hashSHA256 = async (value: string) => {
+  if (!value) {
+    return '';
+  }
+  if (typeof window !== 'undefined' && window.crypto?.subtle) {
+    const encoded = new TextEncoder().encode(value);
+    const buffer = await window.crypto.subtle.digest('SHA-256', encoded);
+    return toHex(buffer);
+  }
+  const nodeCrypto = await import('crypto');
+  return nodeCrypto.createHash('sha256').update(value).digest('hex').toUpperCase();
+};
+
+const hashSHA1 = async (value: string) => {
+  if (!value) {
+    return '';
+  }
+  if (typeof window !== 'undefined' && window.crypto?.subtle) {
+    const encoded = new TextEncoder().encode(value);
+    const buffer = await window.crypto.subtle.digest('SHA-1', encoded);
+    return toHex(buffer);
+  }
+  const nodeCrypto = await import('crypto');
+  return nodeCrypto.createHash('sha1').update(value).digest('hex').toUpperCase();
+};
+
+const checkPasswordReuse = async (password: string, history: string[] = []) => {
+  if (!password || history.length === 0) {
+    return false;
+  }
+  const hash = await hashSHA256(password);
+  return history.includes(hash);
+};
+
+const checkPasswordCompromise = async (password: string, signal?: AbortSignal) => {
+  if (!password) {
+    return false;
+  }
+  try {
+    const hash = await hashSHA1(password);
+    const prefix = hash.slice(0, 5);
+    const suffix = hash.slice(5);
+    const response = await fetch(`https://api.pwnedpasswords.com/range/${prefix}`, {
+      method: 'GET',
+      headers: {
+        'Add-Padding': 'true',
+      },
+      signal,
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const text = await response.text();
+    return text.toUpperCase().split('\n').some((line) => line.startsWith(suffix));
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      return false;
+    }
+    console.warn('Password breach check failed', error);
+    return false;
+  }
+};
+
+export const usePasswordValidation = (
+  password: string,
+  { securitySettings, recentPasswordHashes = [], enableBreachCheck = true }: UsePasswordValidationOptions,
+): UsePasswordValidationResult => {
+  const [validation, setValidation] = useState<PasswordValidation>(() =>
+    validatePassword(password, {
+      minimumLength: securitySettings.minimumLength,
+      requireMixedCase: securitySettings.requireMixedCase,
+      requireNumber: securitySettings.requireNumber,
+      requireSymbol: securitySettings.requireSymbol,
+    }),
+  );
+  const [compromised, setCompromised] = useState(false);
+  const [checkingCompromise, setCheckingCompromise] = useState(false);
+  const [reusedPassword, setReusedPassword] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const runValidation = async () => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+      const reused = await checkPasswordReuse(password, recentPasswordHashes);
+      if (!isMounted) return;
+      setReusedPassword(reused);
+
+      const base = validatePassword(password, {
+        minimumLength: securitySettings.minimumLength,
+        requireMixedCase: securitySettings.requireMixedCase,
+        requireNumber: securitySettings.requireNumber,
+        requireSymbol: securitySettings.requireSymbol,
+        reused,
+      });
+
+      setValidation((prev) => ({
+        ...base,
+        requirements: {
+          ...base.requirements,
+          isNotPwned: prev?.requirements?.isNotPwned ?? true,
+        },
+      }));
+
+      if (!password || !enableBreachCheck) {
+        setCompromised(false);
+        setCheckingCompromise(false);
+        return;
+      }
+
+      abortRef.current = new AbortController();
+      setCheckingCompromise(true);
+      const compromisedResult = await checkPasswordCompromise(password, abortRef.current.signal);
+      if (!isMounted) return;
+      setCompromised(compromisedResult);
+      setValidation((current) => ({
+        ...current,
+        requirements: {
+          ...current.requirements,
+          isNotPwned: !compromisedResult,
+        },
+      }));
+      setCheckingCompromise(false);
+    };
+
+    runValidation();
+
+    return () => {
+      isMounted = false;
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+    };
+  }, [password, securitySettings, recentPasswordHashes, enableBreachCheck]);
+
+  const memoizedValidation = useMemo(() => validation, [validation]);
+
+  const setIsCompromised = useCallback((value: boolean) => {
+    setCompromised(value);
+    setValidation((current) => ({
+      ...current,
+      requirements: {
+        ...current.requirements,
+        isNotPwned: !value,
+      },
+    }));
+  }, []);
+
+  return {
+    validation: memoizedValidation,
+    compromised,
+    checkingCompromise,
+    reusedPassword,
+    setIsCompromised,
+  };
+};

--- a/src/types/security.ts
+++ b/src/types/security.ts
@@ -1,0 +1,71 @@
+export interface PasswordChangeRequest {
+  currentPassword?: string;
+  newPassword: string;
+  confirmPassword: string;
+  twoFactorCode?: string;
+}
+
+export type PasswordStrength = 'weak' | 'fair' | 'good' | 'strong' | 'very-strong';
+
+export interface PasswordValidation {
+  isValid: boolean;
+  strength: PasswordStrength;
+  score: number; // 0-100
+  requirements: {
+    minLength: boolean;
+    hasUppercase: boolean;
+    hasLowercase: boolean;
+    hasNumbers: boolean;
+    hasSymbols: boolean;
+    isNotCommon: boolean;
+    isNotPwned: boolean;
+    matchesHistoryPolicy: boolean;
+  };
+  suggestions: string[];
+}
+
+export interface SecuritySettings {
+  requireCurrentPassword: boolean;
+  enableTwoFactor: boolean;
+  passwordHistoryLimit: number;
+  sessionTimeoutMinutes: number;
+  allowPasswordReset: boolean;
+  minimumLength: number;
+  requireSymbol: boolean;
+  requireNumber: boolean;
+  requireMixedCase: boolean;
+}
+
+export interface AuthenticationState {
+  isAuthenticated: boolean;
+  sessionValid: boolean;
+  userId: string;
+  lastPasswordChange: Date;
+  requiresPasswordChange: boolean;
+}
+
+export interface PasswordSecurityTelemetry {
+  attempts: number;
+  lastAttemptAt?: Date;
+  lockoutExpiresAt?: Date;
+}
+
+export type SecurityAlertVariant =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error';
+
+export interface SecurityAlertMessage {
+  id: string;
+  variant: SecurityAlertVariant;
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export interface PasswordHistoryEntry {
+  hash: string;
+  changedAt: string;
+}

--- a/src/utils/passwordStrength.ts
+++ b/src/utils/passwordStrength.ts
@@ -1,0 +1,81 @@
+import type { PasswordStrength } from '../types/security';
+
+const STRENGTH_THRESHOLDS: Array<{ min: number; strength: PasswordStrength }> = [
+  { min: 0, strength: 'weak' },
+  { min: 25, strength: 'fair' },
+  { min: 45, strength: 'good' },
+  { min: 70, strength: 'strong' },
+  { min: 90, strength: 'very-strong' },
+];
+
+const SEQUENTIAL_PATTERNS = [/abcdefghijklmnopqrstuvwxyz/i, /0123456789/];
+
+export const countCharacterSets = (password: string) => {
+  const sets = {
+    lowercase: /[a-z]/.test(password),
+    uppercase: /[A-Z]/.test(password),
+    numbers: /[0-9]/.test(password),
+    symbols: /[^\da-zA-Z]/.test(password),
+  };
+
+  return {
+    ...sets,
+    fulfilled: Object.values(sets).filter(Boolean).length,
+  };
+};
+
+export const penalizeSequences = (password: string): number => {
+  let penalty = 0;
+  for (const pattern of SEQUENTIAL_PATTERNS) {
+    if (pattern.test(password)) {
+      penalty += 10;
+    }
+  }
+  if (/([a-zA-Z0-9])\1{2,}/.test(password)) {
+    penalty += 15;
+  }
+  return penalty;
+};
+
+export const calculatePasswordScore = (password: string): number => {
+  if (!password) {
+    return 0;
+  }
+
+  const base = Math.min(40, password.length * 3);
+  const { fulfilled } = countCharacterSets(password);
+  const varietyBonus = fulfilled * 12;
+  const uniqueCharacters = new Set(password).size;
+  const uniquenessBonus = Math.min(20, uniqueCharacters * 1.5);
+  const sequencePenalty = penalizeSequences(password);
+
+  const entropyScore = base + varietyBonus + uniquenessBonus - sequencePenalty;
+
+  return Math.max(0, Math.min(100, Math.round(entropyScore)));
+};
+
+export const determineStrength = (score: number): PasswordStrength => {
+  let current: PasswordStrength = 'weak';
+  for (const threshold of STRENGTH_THRESHOLDS) {
+    if (score >= threshold.min) {
+      current = threshold.strength;
+    }
+  }
+  return current;
+};
+
+export const strengthColorMap: Record<PasswordStrength, string> = {
+  'weak': 'bg-red-500',
+  'fair': 'bg-orange-500',
+  'good': 'bg-yellow-500',
+  'strong': 'bg-emerald-500',
+  'very-strong': 'bg-green-600',
+};
+
+export const strengthCopyMap: Record<PasswordStrength, string> = {
+  'weak': 'Weak – vulnerable to attacks',
+  'fair': 'Fair – improve with more variety',
+  'good': 'Good – could still be stronger',
+  'strong': 'Strong – meets recommended policies',
+  'very-strong': 'Very strong – excellent protection',
+};

--- a/src/utils/passwordValidation.ts
+++ b/src/utils/passwordValidation.ts
@@ -1,0 +1,97 @@
+import type { PasswordValidation, PasswordStrength } from '../types/security';
+import { calculatePasswordScore, determineStrength, countCharacterSets } from './passwordStrength';
+
+const COMMON_PASSWORDS = new Set<string>([
+  'password',
+  '123456',
+  '123456789',
+  'qwerty',
+  'letmein',
+  'welcome',
+  'admin',
+  'infoverse',
+  'changeme',
+  'password1',
+]);
+
+export interface ValidatePasswordOptions {
+  minimumLength?: number;
+  reused?: boolean;
+  requireNumber?: boolean;
+  requireSymbol?: boolean;
+  requireMixedCase?: boolean;
+}
+
+const buildSuggestions = (
+  requirements: PasswordValidation['requirements'],
+  strength: PasswordStrength,
+): string[] => {
+  const suggestions: string[] = [];
+  if (!requirements.minLength) {
+    suggestions.push('Use at least twelve characters.');
+  }
+  if (!requirements.hasUppercase) {
+    suggestions.push('Add uppercase characters (A-Z).');
+  }
+  if (!requirements.hasLowercase) {
+    suggestions.push('Include lowercase characters (a-z).');
+  }
+  if (!requirements.hasNumbers) {
+    suggestions.push('Mix in numbers to increase complexity.');
+  }
+  if (!requirements.hasSymbols) {
+    suggestions.push('Add special characters like ! @ # %.');
+  }
+  if (!requirements.isNotCommon) {
+    suggestions.push('Avoid commonly used or compromised passwords.');
+  }
+  if (!requirements.matchesHistoryPolicy) {
+    suggestions.push('Choose a password you have not used recently.');
+  }
+  if (strength === 'fair' || strength === 'weak') {
+    suggestions.push('Consider using a passphrase of unrelated words.');
+  }
+  return suggestions;
+};
+
+export const validatePassword = (
+  password: string,
+  options: ValidatePasswordOptions = {},
+): PasswordValidation => {
+  const minimumLength = options.minimumLength ?? 12;
+  const hasUppercase = /[A-Z]/.test(password);
+  const hasLowercase = /[a-z]/.test(password);
+  const hasNumbers = /\d/.test(password);
+  const hasSymbols = /[^\da-zA-Z]/.test(password);
+  const isNotCommon = password ? !COMMON_PASSWORDS.has(password.toLowerCase()) : false;
+  const matchesHistoryPolicy = options.reused ? !options.reused : true;
+
+  const requirements = {
+    minLength: password.length >= minimumLength,
+    hasUppercase: options.requireMixedCase ? hasUppercase : hasUppercase || !password,
+    hasLowercase: options.requireMixedCase ? hasLowercase : hasLowercase || !password,
+    hasNumbers: options.requireNumber ? hasNumbers : hasNumbers || !password,
+    hasSymbols: options.requireSymbol ? hasSymbols : hasSymbols || !password,
+    isNotCommon,
+    isNotPwned: true,
+    matchesHistoryPolicy,
+  };
+
+  const score = calculatePasswordScore(password);
+  const strength: PasswordStrength = determineStrength(score);
+  const fulfilled = Object.values(requirements).filter(Boolean).length;
+  const isValid = fulfilled >= 7 && score >= 45;
+  const suggestions = buildSuggestions(requirements, strength);
+
+  return {
+    isValid,
+    strength,
+    score,
+    requirements,
+    suggestions,
+  };
+};
+
+export const evaluateCharacterDiversity = (password: string) => countCharacterSets(password);
+
+export const isCommonPassword = (password: string) => COMMON_PASSWORDS.has(password.toLowerCase());


### PR DESCRIPTION
## Summary
- implement a Next.js-style change password page with session-aware authentication wrapper
- build a secure password form with strength meter, breach checking, and multi-factor prompts
- add reusable security utilities, hooks, and types for advanced password validation and policies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0716365d4832aabc1955505f6d503